### PR TITLE
MAINT: Add black profile to isort, isort to pre-commit

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,3 +18,7 @@ repos:
     rev: 22.3.0
     hooks:
     -   id: black
+-   repo: https://github.com/pycqa/isort
+    rev: 5.10.1
+    hooks:
+    -   id: isort

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,3 +26,7 @@ exclude = '''
 )/
 '''
 line-length = 99
+
+[tool.isort]
+profile = 'black'
+skip_gitignore = true


### PR DESCRIPTION
Adds a few touch ups to pre-commit

- Adds black profile to isort, to ensure compatibility between the two linters
- Adds isort to the pre-commit gauntlet