### PR TITLE
FIX: Plugin inclusion via main bootstrap file did not work

### DIFF
--- a/nireports/assembler/data/default.yml
+++ b/nireports/assembler/data/default.yml
@@ -253,6 +253,5 @@ sections:
 
 # Example pluging specification in bootstrap file:
 # plugins:
-# - rating-widget:
-#     module: nireports.assembler
-#     path: data/rating-widget/bootstrap.yml
+# - module: nireports.assembler
+#   path: data/rating-widget/bootstrap.yml

--- a/nireports/assembler/report.py
+++ b/nireports/assembler/report.py
@@ -294,7 +294,7 @@ class Report:
         self.index(settings)
 
         # Override plugins specified in the bootstrap with arg
-        if plugins is not None:
+        if plugins is not None or (plugins := settings.get("plugins", [])):
             settings["plugins"] = [
                 load(Path(pkgrf(plugin["module"], plugin["path"])).read_text())
                 for plugin in plugins


### PR DESCRIPTION
This PR removes one dictionary level in the configuration of plugins. This was already effected on the initialization via ``plugins`` argument of the ``Report``, but didn't work for the bootstrap file.