### PR TITLE
ENH: Add a ``bval-<label>`` entity

### DIFF
--- a/nireports/assembler/data/nipreps.json
+++ b/nireports/assembler/data/nipreps.json
@@ -173,6 +173,11 @@
       "dtype": "int",
       "name": "cohort",
       "pattern": "[_/\\\\]+cohort-0*(\\d+)"
+    },
+    {
+      "dtype": "int",
+      "name": "bval",
+      "pattern": "[_/\\\\]+bval-0*(\\d+)"
     }
   ],
   "name": "nipreps"


### PR DESCRIPTION
Necessary for MRIQC's dwi results