### PR TITLE
Add `ignore_initial_volumes` param to `ConfoundsCorrelationPlot`

### DIFF
--- a/nireports/interfaces/nuisance.py
+++ b/nireports/interfaces/nuisance.py
@@ -113,6 +113,12 @@ class _ConfoundsCorrelationPlotInputSpec(BaseInterfaceInputSpec):
         "correlation with `reference_column` will be "
         "selected.",
     )
+    ignore_initial_volumes = traits.Int(
+        0,
+        usedefault=True,
+        desc="Number of non-steady-state volumes at the beginning of the scan "
+        "to ignore.",
+    )
 
 
 class _ConfoundsCorrelationPlotOutputSpec(TraitedSpec):
@@ -141,5 +147,6 @@ class ConfoundsCorrelationPlot(SimpleInterface):
             max_dim=self.inputs.max_dim,
             output_file=self._results["out_file"],
             reference=self.inputs.reference_column,
+            ignore_initial_volumes=self.inputs.ignore_initial_volumes,
         )
         return runtime

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -812,6 +812,7 @@ def confounds_correlation_plot(
     max_dim=20,
     output_file=None,
     reference="global_signal",
+    ignore_initial_volumes=0,
 ):
     """
     Generate a bar plot with the correlation of confounds.
@@ -840,6 +841,8 @@ def confounds_correlation_plot(
         of each confound regressor with a reference column. By default, this
         is the global signal (so that collinearities with the global signal
         can readily be assessed).
+    ignore_initial_volumes : :obj:`int`
+        Number of non-steady-state volumes at the beginning of the scan to ignore.
 
     Returns
     -------
@@ -859,7 +862,8 @@ def confounds_correlation_plot(
         confounds_data = confounds_data[list(columns)]
 
     confounds_data = confounds_data.loc[
-        :, np.logical_not(np.isclose(confounds_data.var(skipna=True), 0))
+        ignore_initial_volumes:,
+        np.logical_not(np.isclose(confounds_data.var(skipna=True), 0)),
     ]
     corr = confounds_data.corr()
 

--- a/nireports/tests/conftest.py
+++ b/nireports/tests/conftest.py
@@ -1,0 +1,31 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2021 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+""" py.test configuration file """
+import os
+
+import pytest
+
+
+@pytest.fixture(scope="session")
+def datadir():
+    return os.path.abspath(os.path.join(os.path.dirname(__file__), "data") + os.path.sep)

--- a/nireports/tests/test_interfaces.py
+++ b/nireports/tests/test_interfaces.py
@@ -21,3 +21,45 @@
 #     https://www.nipreps.org/community/licensing/
 #
 """Tests plotting interfaces."""
+import os
+from shutil import copy
+from nireports.interfaces.nuisance import CompCorVariancePlot, ConfoundsCorrelationPlot
+
+
+def _smoke_test_report(report_interface, artifact_name):
+    out_report = report_interface.run().outputs.out_file
+
+    save_artifacts = os.getenv("SAVE_CIRCLE_ARTIFACTS", False)
+    if save_artifacts:
+        copy(out_report, os.path.join(save_artifacts, artifact_name))
+    assert os.path.isfile(out_report), 'Report "%s" does not exist' % out_report
+
+
+def test_CompCorVariancePlot(datadir):
+    """CompCor variance report test"""
+    metadata_file = os.path.join(datadir, "confounds_metadata_test.tsv")
+    cc_rpt = CompCorVariancePlot(metadata_files=[metadata_file], metadata_sources=["aCompCor"])
+    _smoke_test_report(cc_rpt, "compcor_variance.svg")
+
+
+def test_ConfoundsCorrelationPlot(datadir):
+    """confounds correlation report test"""
+    confounds_file = os.path.join(datadir, "confounds_test.tsv")
+    cc_rpt = ConfoundsCorrelationPlot(
+        confounds_file=confounds_file,
+        reference_column="a",
+        ignore_initial_volumes=1,
+    )
+    _smoke_test_report(cc_rpt, "confounds_correlation.svg")
+
+
+def test_ConfoundsCorrelationPlotColumns(datadir):
+    """confounds correlation report test"""
+    confounds_file = os.path.join(datadir, "confounds_test.tsv")
+    cc_rpt = ConfoundsCorrelationPlot(
+        confounds_file=confounds_file,
+        reference_column="a",
+        columns=["b", "d", "f"],
+        ignore_initial_volumes=0,
+    )
+    _smoke_test_report(cc_rpt, "confounds_correlation_cols.svg")

--- a/nireports/tests/test_interfaces.py
+++ b/nireports/tests/test_interfaces.py
@@ -45,8 +45,8 @@ def test_CompCorVariancePlot(datadir):
     _smoke_test_report(cc_rpt, "compcor_variance.svg")
 
 
-@pytest.mark.parametrize(ignore_initial_volumes, (0, 1))
-def test_ConfoundsCorrelationPlot(datadir):
+@pytest.mark.parametrize('ignore_initial_volumes', (0, 1))
+def test_ConfoundsCorrelationPlot(datadir, ignore_initial_volumes):
     """confounds correlation report test"""
     confounds_file = os.path.join(datadir, "confounds_test.tsv")
     cc_rpt = ConfoundsCorrelationPlot(

--- a/nireports/tests/test_interfaces.py
+++ b/nireports/tests/test_interfaces.py
@@ -23,6 +23,9 @@
 """Tests plotting interfaces."""
 import os
 from shutil import copy
+
+import pytest
+
 from nireports.interfaces.nuisance import CompCorVariancePlot, ConfoundsCorrelationPlot
 
 
@@ -42,24 +45,13 @@ def test_CompCorVariancePlot(datadir):
     _smoke_test_report(cc_rpt, "compcor_variance.svg")
 
 
+@pytest.mark.parametrize(ignore_initial_volumes, (0, 1))
 def test_ConfoundsCorrelationPlot(datadir):
     """confounds correlation report test"""
     confounds_file = os.path.join(datadir, "confounds_test.tsv")
     cc_rpt = ConfoundsCorrelationPlot(
         confounds_file=confounds_file,
         reference_column="a",
-        ignore_initial_volumes=1,
+        ignore_initial_volumes=ignore_initial_volumes,
     )
-    _smoke_test_report(cc_rpt, "confounds_correlation.svg")
-
-
-def test_ConfoundsCorrelationPlotColumns(datadir):
-    """confounds correlation report test"""
-    confounds_file = os.path.join(datadir, "confounds_test.tsv")
-    cc_rpt = ConfoundsCorrelationPlot(
-        confounds_file=confounds_file,
-        reference_column="a",
-        columns=["b", "d", "f"],
-        ignore_initial_volumes=0,
-    )
-    _smoke_test_report(cc_rpt, "confounds_correlation_cols.svg")
+    _smoke_test_report(cc_rpt, f"confounds_correlation_{ignore_initial_volumes}.svg")


### PR DESCRIPTION
Related to https://github.com/nipreps/niworkflows/pull/843.

Changes proposed:

- Add an `ignore_initial_volumes` parameter to the `ConfoundsCorrelationPlot` interface.
- Add an `ignore_initial_volumes` parameter to the `confounds_correlation_plot` function.