### PR TITLE
MNT: Fix matplotlib.cm.get_cmap deprecation

### DIFF
--- a/nireports/reportlets/mosaic.py
+++ b/nireports/reportlets/mosaic.py
@@ -29,9 +29,9 @@ from os import path as op
 import math
 import numpy as np
 import nibabel as nb
+from matplotlib import colormaps
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
-from matplotlib.cm import get_cmap
 from svgutils.transform import fromstring
 from nilearn.plotting import plot_anat
 from nilearn import image as nlimage
@@ -269,7 +269,7 @@ def plot_slice(
     annotate=None,
 ):
     if isinstance(cmap, (str, bytes)):
-        cmap = get_cmap(cmap)
+        cmap = colormaps[cmap]
 
     est_vmin, est_vmax = _get_limits(dslice)
     if not vmin:
@@ -359,7 +359,7 @@ def plot_slice_tern(
 ):
 
     if isinstance(cmap, (str, bytes)):
-        cmap = get_cmap(cmap)
+        cmap = colormaps[cmap]
 
     est_vmin, est_vmax = _get_limits(dslice)
     if not vmin:

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -27,8 +27,8 @@ import math
 import os.path as op
 
 import numpy as np
+from matplotlib import colormaps
 import matplotlib.pyplot as plt
-from matplotlib.cm import get_cmap
 import seaborn as sns
 from matplotlib.backends.backend_pdf import FigureCanvasPdf as FigureCanvas
 from matplotlib.gridspec import GridSpec, GridSpecFromSubplotSpec
@@ -274,9 +274,9 @@ def plot_carpet(
         legend = False
 
     if cmap is None:
-        colors = get_cmap("tab10").colors
+        colors = colormaps["tab10"].colors
     elif cmap == "paired":
-        colors = list(get_cmap("Paired").colors)
+        colors = list(colormaps["Paired"].colors)
         colors[0], colors[1] = colors[1], colors[0]
         colors[2], colors[7] = colors[7], colors[2]
 
@@ -469,7 +469,7 @@ def spikesplot(
     ntsteps = ts_z.shape[1]
 
     # Load a colormap
-    my_cmap = get_cmap(cmap)
+    my_cmap = colormaps[cmap]
     norm = Normalize(vmin=0, vmax=float(nslices - 1))
     colors = [my_cmap(norm(sl)) for sl in range(nslices)]
 
@@ -597,7 +597,7 @@ def spikesplot_cb(position, cmap="viridis", fig=None):
     cax = fig.add_axes(position)
     cb = ColorbarBase(
         cax,
-        cmap=get_cmap(cmap),
+        cmap=colormaps[cmap],
         spacing="proportional",
         orientation="horizontal",
         drawedges=False,


### PR DESCRIPTION
See https://github.com/nipreps/niworkflows/pull/866.

Fixes CI errors in https://github.com/nipreps/fmriprep/pull/3280.