### PR TITLE
STY: Apply ruff/flake8-implicit-str-concat rule ISC001

### DIFF
--- a/nireports/interfaces/nuisance.py
+++ b/nireports/interfaces/nuisance.py
@@ -38,7 +38,7 @@ class _CompCorVariancePlotInputSpec(BaseInterfaceInputSpec):
     metadata_files = traits.List(
         File(exists=True),
         mandatory=True,
-        desc="List of files containing component " "metadata",
+        desc="List of files containing component metadata",
     )
     metadata_sources = traits.List(
         traits.Str,
@@ -51,7 +51,7 @@ class _CompCorVariancePlotInputSpec(BaseInterfaceInputSpec):
         traits.Float(0.7),
         traits.Float(0.9),
         usedefault=True,
-        desc="Levels of explained variance to include in " "plot",
+        desc="Levels of explained variance to include in plot",
     )
     out_file = traits.Either(
         None, File, value=None, usedefault=True, desc="Path to save plot"


### PR DESCRIPTION
	ISC001 Implicitly concatenated string literals on one line

This rule is currently disabled because it conflicts with the formatter: https://github.com/astral-sh/ruff/issues/8272