### PR TITLE
ENH: Set the `seaborn` barplot `hue` property value

### DIFF
--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -899,10 +899,12 @@ def confounds_correlation_plot(
         data=gscorr,
         x="index",
         y=reference,
+        hue="index",
         ax=ax1,
         order=gs_descending,
         palette="Reds_d",
         saturation=0.5,
+        legend=False,
     )
 
     ax1.set_xlabel("Confound time series")


### PR DESCRIPTION
Set the `seaborn` barplot `hue` property value and set the `legend` property to `False`.

Fixes:
```
/opt/conda/envs/fmriprep/lib/python3.10/site-packages/nireports/reportlets/nuisance.py:898:
 FutureWarning:

Passing `palette` without assigning `hue` is deprecated and will be removed in v0.14.0.
Assign the `x` variable to `hue` and set `legend=False` for the same effect.
```

Fixes #89.