### PR TITLE
DOC: Fix `dwi` module function cross ref in docstring

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -50,7 +50,6 @@ extensions = [
 autodoc_mock_imports = [
     "nilearn",
     "nitime",
-    "numpy",
     "pandas",
     "seaborn",
     "skimage",

--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -310,7 +310,7 @@ def plot_gradients(
     Draw the vectors on a unit sphere using a different color (as given by the
     ``colormap`` property in the extra keywowrd arguments) for each b-value.
 
-    .. seealso:: :meth:`~nireports.reportlets.modality.dwi.draw_points`.
+    .. seealso:: :func:`draw_points`.
 
     Parameters
     ----------
@@ -323,7 +323,7 @@ def plot_gradients(
     spacing : :obj:`float`
         Plot spacing.
     kwargs : :obj:`dict`
-        Extra args given to :meth:`~nireports.reportlets.modality.dwi.draw_points`.
+        Extra args given to :func:`draw_points`.
 
     Returns
     -------

--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -139,6 +139,7 @@ def rotation_matrix(u, v):
     All rights reserved.
 
     .. admonition :: List of changes
+
         Only minimal updates to leverage Numpy.
 
     Parameters
@@ -191,6 +192,7 @@ def draw_circles(positions, radius, n_samples=20):
     All rights reserved.
 
     .. admonition :: List of changes
+
         Modified to take the full list of normalized bvecs and corresponding circle
         radii instead of taking the list of bvecs and radii for a specific shell
         (*b*-value).
@@ -239,6 +241,7 @@ def draw_points(gradients, ax, rad_min=0.3, rad_max=0.7, colormap="viridis"):
     All rights reserved.
 
     .. admonition :: List of changes
+
         * The input is a single 2D numpy array of the gradient table in RAS+B format
         * The scaling of the circle radius for each bvec proportional to the inverse of
           the bvals. A minimum/maximal value for the radii can be specified.

--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -307,7 +307,10 @@ def plot_gradients(
     **kwargs,
 ):
     """
-    Draw the vectors on a unit sphere with color code for multiple b-values.
+    Draw the vectors on a unit sphere using a different color (as given by the
+    ``colormap`` property in the extra keywowrd arguments) for each b-value.
+
+    .. seealso:: :meth:`~nireports.reportlets.modality.dwi.draw_points`.
 
     Parameters
     ----------
@@ -320,7 +323,7 @@ def plot_gradients(
     spacing : :obj:`float`
         Plot spacing.
     kwargs : :obj:`dict`
-        Extra args given to :obj:`eddymotion.viz.draw_points()`.
+        Extra args given to :meth:`~nireports.reportlets.modality.dwi.draw_points`.
 
     Returns
     -------


### PR DESCRIPTION
Fix `dwi` module function cross ref in docstring: provide the appropriate module where `draw_points` dwells.

Introduced inadvertently in commit 9f561d1 when the code was relocated from `eddymotion`.

Take advantage of the commit to improve the description of the method:
- Specify how the colors are assigned.
- Cross-reference the `draw_points` function using the Sphinx `seealso` tag.
- Use the tilde to shorten the link: display only the function name without the modules.