### PR TITLE
RF: Consistently use matplotlib.colormaps in mpl namespace

### DIFF
--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -22,8 +22,8 @@
 #
 """Visualizations for diffusion MRI data."""
 import numpy as np
+import matplotlib as mpl
 from matplotlib import pyplot as plt
-from matplotlib.pyplot import cm
 from mpl_toolkits.mplot3d import art3d
 
 
@@ -258,7 +258,7 @@ def draw_points(gradients, ax, rad_min=0.3, rad_max=0.7, colormap="viridis"):
         Minimum radius of the circle that renders a gradient direction.
     rad_max : :obj:`float` between 0 and 1
         Maximum radius of the circle that renders a gradient direction.
-    colormap : :obj:`matplotlib.pyplot.cm.ColorMap`
+    colormap : :class:`str`
         matplotlib colormap name.
 
     """
@@ -273,7 +273,7 @@ def draw_points(gradients, ax, rad_min=0.3, rad_max=0.7, colormap="viridis"):
     bvals = bvals / bvals.max()
 
     # Colormap depending on bvalue (for visualization)
-    cmap = cm.get_cmap(colormap)
+    cmap = mpl.colormaps[colormap]
     colors = cmap(bvals)
 
     # Relative shell radii proportional to the inverse of bvalue (for visualization)

--- a/nireports/reportlets/mosaic.py
+++ b/nireports/reportlets/mosaic.py
@@ -29,7 +29,7 @@ from os import path as op
 import math
 import numpy as np
 import nibabel as nb
-from matplotlib import colormaps
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 from matplotlib.gridspec import GridSpec
 from svgutils.transform import fromstring
@@ -269,7 +269,7 @@ def plot_slice(
     annotate=None,
 ):
     if isinstance(cmap, (str, bytes)):
-        cmap = colormaps[cmap]
+        cmap = mpl.colormaps[cmap]
 
     est_vmin, est_vmax = _get_limits(dslice)
     if not vmin:
@@ -359,7 +359,7 @@ def plot_slice_tern(
 ):
 
     if isinstance(cmap, (str, bytes)):
-        cmap = colormaps[cmap]
+        cmap = mpl.colormaps[cmap]
 
     est_vmin, est_vmax = _get_limits(dslice)
     if not vmin:
@@ -665,9 +665,7 @@ def plot_mosaic(
             )
 
             if overlay_mask:
-                from matplotlib import cm
-
-                msk_cmap = cm.Reds  # @UndefinedVariable
+                msk_cmap = mpl.colormaps['Reds']
                 msk_cmap._init()
                 alphas = np.linspace(0, 0.75, msk_cmap.N + 3)
                 msk_cmap._lut[:, -1] = alphas

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -27,7 +27,7 @@ import math
 import os.path as op
 
 import numpy as np
-from matplotlib import colormaps
+import matplotlib as mpl
 import matplotlib.pyplot as plt
 import seaborn as sns
 from matplotlib.backends.backend_pdf import FigureCanvasPdf as FigureCanvas
@@ -274,9 +274,9 @@ def plot_carpet(
         legend = False
 
     if cmap is None:
-        colors = colormaps["tab10"].colors
+        colors = mpl.colormaps["tab10"].colors
     elif cmap == "paired":
-        colors = list(colormaps["Paired"].colors)
+        colors = list(mpl.colormaps["Paired"].colors)
         colors[0], colors[1] = colors[1], colors[0]
         colors[2], colors[7] = colors[7], colors[2]
 
@@ -469,7 +469,7 @@ def spikesplot(
     ntsteps = ts_z.shape[1]
 
     # Load a colormap
-    my_cmap = colormaps[cmap]
+    my_cmap = mpl.colormaps[cmap]
     norm = Normalize(vmin=0, vmax=float(nslices - 1))
     colors = [my_cmap(norm(sl)) for sl in range(nslices)]
 
@@ -597,7 +597,7 @@ def spikesplot_cb(position, cmap="viridis", fig=None):
     cax = fig.add_axes(position)
     cb = ColorbarBase(
         cax,
-        cmap=colormaps[cmap],
+        cmap=mpl.colormaps[cmap],
         spacing="proportional",
         orientation="horizontal",
         drawedges=False,


### PR DESCRIPTION
A `cm.get_cmap()` snuck in since #98. To make clear that `colormaps` is not a local dictionary, I'm switching to using it from the `mpl` namespace.