### PR TITLE
ENH: Support PNGs and JPGs in reportlets

### DIFF
--- a/nireports/assembler/report.py
+++ b/nireports/assembler/report.py
@@ -220,9 +220,6 @@ class Report:
     ... ).read_text()) - (REPORT_BASELINE_LENGTH + 51892)
     0
 
-    >>> (output_dir / 'nireports' / 'sub-03_task-faketaskwithruns_bold.html').read_text()
-    "test"
-
     >>> len((
     ...     output_dir / 'nireports' / 'sub-03_task-faketaskwithruns_bold.html'
     ... ).read_text()) - RATING_WIDGET_LENGTH

--- a/nireports/assembler/report.py
+++ b/nireports/assembler/report.py
@@ -220,6 +220,9 @@ class Report:
     ... ).read_text()) - (REPORT_BASELINE_LENGTH + 51892)
     0
 
+    >>> (output_dir / 'nireports' / 'sub-03_task-faketaskwithruns_bold.html').read_text()
+    "test"
+
     >>> len((
     ...     output_dir / 'nireports' / 'sub-03_task-faketaskwithruns_bold.html'
     ... ).read_text()) - RATING_WIDGET_LENGTH

--- a/nireports/assembler/reportlet.py
+++ b/nireports/assembler/reportlet.py
@@ -264,7 +264,7 @@ class Reportlet:
                     style = {"width": "100%"} if is_static else {}
                     style.update(config.get("style", {}))
 
-                    snippet = SVG_SNIPPET if is_static else IMG_SNIPPET
+                    snippet = IMG_SNIPPET if is_static else SVG_SNIPPET
                     contents = snippet.format(
                         ext=ext[1:],
                         name=html_anchor,

--- a/nireports/assembler/reportlet.py
+++ b/nireports/assembler/reportlet.py
@@ -270,6 +270,26 @@ class Reportlet:
                         name=html_anchor,
                         style="; ".join(f"{k}: {v}" for k, v in style.items()),
                     )
+                elif ext in (".png", ".jpg", ".jpeg"):
+                    entities = dict(bidsfile.entities)
+                    if desc_text:
+                        desc_text = desc_text.format(**entities)
+
+                    try:
+                        html_anchor = src.relative_to(out_dir)
+                    except ValueError:
+                        html_anchor = src.relative_to(Path(layout.root))
+                        dst = out_dir / html_anchor
+                        dst.parent.mkdir(parents=True, exist_ok=True)
+                        copyfile(src, dst, copy=True, use_hardlink=True)
+
+                    style = {"width": "100%"} if is_static else {}
+                    style.update(config.get("style", {}))
+
+                    stylestr = "; ".join(f"{k}: {v}" for k, v in style.items())
+                    contents = f'<img src="{html_anchor}" style="{stylestr}"/>'
+                else:
+                    raise RuntimeError(f"Unsupported file extension: {ext}")
 
                 if contents:
                     self.components.append((contents, desc_text))

--- a/nireports/assembler/reportlet.py
+++ b/nireports/assembler/reportlet.py
@@ -31,22 +31,20 @@ from nireports.assembler import data
 from nireports.assembler.misc import dict2html, read_crashfile
 
 
-SVG_SNIPPET = [
-    """\
+IMG_SNIPPET = """\
 <div class="reportlet">
-<object class="svg-reportlet" type="image/svg+xml" data="./{name}" style="{style}">
+<img class="{ext}-reportlet" src="./{name}" style="{style}" />
+</div>
+<small>Get figure file: <a href="./{name}" target="_blank">{name}</a></small>
+"""
+SVG_SNIPPET = """\
+<div class="reportlet">
+<object class="{ext}-reportlet" type="image/{ext}+xml" data="./{name}" style="{style}">
 Problem loading figure {name}. If the link below works, please try \
 reloading the report in your browser.</object>
 </div>
 <small>Get figure file: <a href="./{name}" target="_blank">{name}</a></small>
-""",
-    """\
-<div class="reportlet">
-<img class="svg-reportlet" src="./{name}" style="{style}" />
-</div>
-<small>Get figure file: <a href="./{name}" target="_blank">{name}</a></small>
-""",
-]
+"""
 
 METADATA_ACCORDION_BLOCK = """\
 <div class="accordion accordion-flush" id="{metadata_id}">
@@ -266,7 +264,9 @@ class Reportlet:
                     style = {"width": "100%"} if is_static else {}
                     style.update(config.get("style", {}))
 
-                    contents = SVG_SNIPPET[is_static].format(
+                    snippet = SVG_SNIPPET if is_static else IMG_SNIPPET
+                    contents = snippet.format(
+                        ext=ext[1:],
                         name=html_anchor,
                         style="; ".join(f"{k}: {v}" for k, v in style.items()),
                     )
@@ -283,11 +283,15 @@ class Reportlet:
                         dst.parent.mkdir(parents=True, exist_ok=True)
                         copyfile(src, dst, copy=True, use_hardlink=True)
 
-                    style = {"width": "100%"} if is_static else {}
+                    style = {"width": "100%"}
                     style.update(config.get("style", {}))
 
-                    stylestr = "; ".join(f"{k}: {v}" for k, v in style.items())
-                    contents = f'<img src="{html_anchor}" style="{stylestr}"/>'
+                    snippet = IMG_SNIPPET
+                    contents = snippet.format(
+                        ext=ext[1:],
+                        name=html_anchor,
+                        style="; ".join(f"{k}: {v}" for k, v in style.items()),
+                    )
                 else:
                     raise RuntimeError(f"Unsupported file extension: {ext}")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -41,10 +41,10 @@ NiPreps = "https://www.nipreps.org/"
 
 [project.optional-dependencies]
 doc = [
-    "furo ~= 2021.10.09",
+    "furo",
     "pydot >= 1.2.3",
     "pydotplus",
-    "sphinx ~= 4.0",
+    "sphinx",
     "sphinxcontrib-apidoc",
     "sphinxcontrib-napoleon",
 ]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "nibabel >= 3.0.1",
     "nilearn >= 0.5.2",
     "nipype",
-    "numpy",
+    "numpy < 2.0.0",
     "pandas",
     "pybids",
     "pyyaml",


### PR DESCRIPTION
Closes https://github.com/nipreps/nireports/issues/124.

Changes proposed:

- Add a section to embed PNGs and JPGs in the HTML report.
- Raise an exception if an extension isn't supported.