### PR TITLE
test: Numpy 2.0 compatibility

### DIFF
--- a/nireports/conftest.py
+++ b/nireports/conftest.py
@@ -41,6 +41,14 @@ test_output_dir = os.getenv("TEST_OUTPUT_DIR")
 test_workdir = os.getenv("TEST_WORK_DIR")
 
 
+@pytest.fixture(scope="session", autouse=True)
+def legacy_printoptions():
+    from packaging.version import Version
+
+    if Version(np.__version__) >= Version("1.22"):
+        np.set_printoptions(legacy="1.21")
+
+
 @pytest.fixture(autouse=True)
 def expand_namespace(doctest_namespace):
     doctest_namespace["PY_VERSION"] = version_info

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,7 +24,7 @@ dependencies = [
     "nibabel >= 3.0.1",
     "nilearn >= 0.5.2",
     "nipype",
-    "numpy < 2.0",
+    "numpy",
     "pandas",
     "pybids",
     "pyyaml",
@@ -57,6 +57,7 @@ dev = [
 test = [
     "coverage",
     "matplotlib",
+    "packaging",
     "pytest",
     "pytest-cov",
     "pytest-env",


### PR DESCRIPTION
Tell numpy to use legacy formatting during tests. This changes annoying things like `numpy.float32(0.0)` to `0.0` again.