### PR TITLE
FIX: Address memory issues and corruption in ``fMRIPlot``

### DIFF
--- a/nireports/assembler/tests/test_report.py
+++ b/nireports/assembler/tests/test_report.py
@@ -87,6 +87,7 @@ def bids_sessions(tmpdir_factory):
         file_path = svg_dir / bids_path
         file_path.ensure()
         f.savefig(str(file_path))
+        f.clf()
 
     # create anatomical data
     anat_opts = [
@@ -110,6 +111,7 @@ def bids_sessions(tmpdir_factory):
         file_path = svg_dir / bids_path
         file_path.ensure()
         f.savefig(str(file_path))
+        f.clf()
 
     return svg_dir.dirname
 

--- a/nireports/interfaces/dmri.py
+++ b/nireports/interfaces/dmri.py
@@ -93,5 +93,7 @@ class DWIHeatmap(SimpleInterface):
         )
 
         out_figure.savefig(self._results["out_file"], format="svg", dpi=300)
+        out_figure.clf()
+        out_figure = None
 
         return runtime

--- a/nireports/interfaces/fmri.py
+++ b/nireports/interfaces/fmri.py
@@ -98,7 +98,7 @@ class FMRISummary(SimpleInterface):
             else nifti_timeseries(input_data, seg_file)
         )
 
-        fig = fMRIPlot(
+        fMRIPlot(
             dataset,
             segments=segments,
             spikes_files=(
@@ -109,6 +109,6 @@ class FMRISummary(SimpleInterface):
             units={"outliers": "%", "FD": "mm"},
             vlines={"FD": [self.inputs.fd_thres]},
             nskip=self.inputs.drop_trs,
-        ).plot()
-        fig.savefig(self._results["out_file"], bbox_inches="tight")
+        ).plot(out_file=self._results["out_file"])
+
         return runtime

--- a/nireports/reportlets/modality/func.py
+++ b/nireports/reportlets/modality/func.py
@@ -89,22 +89,25 @@ class fMRIPlot:
             for sp_file in spikes_files:
                 self.spikes.append((np.loadtxt(sp_file), None, False))
 
-    def plot(self, figure=None):
+    def plot(self, figure=None, out_file=None):
         """Main plotter"""
-        import seaborn as sns
-
-        sns.set_style("whitegrid")
-        sns.set_context("paper", font_scale=0.8)
 
         if figure is None:
-            figure = plt.gcf()
+            figure = plt.figure(figsize=(19.2, 32))
 
         nconfounds = len(self.confounds)
         nspikes = len(self.spikes)
         nrows = 1 + nconfounds + nspikes
 
         # Create grid
-        grid = GridSpec(nrows, 1, wspace=0.0, hspace=0.05, height_ratios=[1] * (nrows - 1) + [5])
+        grid = GridSpec(
+            nrows,
+            1,
+            figure=figure,
+            wspace=0.0,
+            hspace=0.05,
+            height_ratios=[1] * (nrows - 1) + [5],
+        )
 
         grid_id = 0
         for tsz, name, iszs in self.spikes:
@@ -130,4 +133,11 @@ class fMRIPlot:
             drop_trs=self.nskip,
             cmap="paired" if self.paired_carpet else None,
         )
+
+        if out_file is not None:
+            figure.savefig(out_file, bbox_inches="tight")
+            plt.close(figure)
+            figure = None
+            return out_file
+
         return figure

--- a/nireports/reportlets/modality/func.py
+++ b/nireports/reportlets/modality/func.py
@@ -89,15 +89,20 @@ class fMRIPlot:
             for sp_file in spikes_files:
                 self.spikes.append((np.loadtxt(sp_file), None, False))
 
-    def plot(self, figure=None, out_file=None):
+    def plot(self, figure=None, out_file=None, fontsize=24):
         """Main plotter"""
 
-        if figure is None:
-            figure = plt.figure(figsize=(19.2, 32))
+        plt.rcParams.update({'font.size': 22})
 
         nconfounds = len(self.confounds)
         nspikes = len(self.spikes)
         nrows = 1 + nconfounds + nspikes
+
+        # Calculate height ratios in figure points
+        height_ratios = [0.8] * (nconfounds + nspikes) + [10]
+
+        if figure is None:
+            figure = plt.figure(figsize=(19.2, sum(height_ratios)))
 
         # Create grid
         grid = GridSpec(
@@ -106,7 +111,7 @@ class fMRIPlot:
             figure=figure,
             wspace=0.0,
             hspace=0.05,
-            height_ratios=[1] * (nrows - 1) + [5],
+            height_ratios=height_ratios,
         )
 
         grid_id = 0

--- a/nireports/reportlets/modality/func.py
+++ b/nireports/reportlets/modality/func.py
@@ -92,7 +92,7 @@ class fMRIPlot:
     def plot(self, figure=None, out_file=None, fontsize=24):
         """Main plotter"""
 
-        plt.rcParams.update({'font.size': 22})
+        plt.rcParams.update({"font.size": 22})
 
         nconfounds = len(self.confounds)
         nspikes = len(self.spikes)

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -230,6 +230,7 @@ def plot_carpet(
     sort_rows="ward",
     drop_trs=0,
     legend=True,
+    fontsize=None,
 ):
     """
     Plot an image representation of voxel intensities across time.
@@ -323,7 +324,15 @@ def plot_carpet(
 
     # If subplot is not defined
     if subplot is None:
-        subplot = GridSpec(1, 1)[0]
+        figure, allaxes = plt.subplots(figsize=(19.2, 10))
+        allaxes.spines[:].set_visible(False)
+        allaxes.spines[:].set_color('none')
+        allaxes.get_xaxis().set_visible(False)
+        allaxes.get_yaxis().set_visible(False)
+        subplot = allaxes.get_subplotspec()
+        fontsize = fontsize or 24
+    else:
+        figure = plt.gcf()
 
     # Length before decimation
     n_trs = data.shape[-1] - drop_trs
@@ -428,11 +437,22 @@ def plot_carpet(
             fancybox=False,
             ncol=min(len(segments.keys()), 5),
             frameon=False,
-            prop={"size": 8},
+            prop={"size": fontsize} if fontsize else {},
         )
 
+    if fontsize is not None:
+        ax.xaxis.label.set_fontsize(
+            max(8, fontsize * 0.75)
+        )
+        # Change font size according to figure size
+        for item in (
+            [ax.title, ax.yaxis.label]
+            + ax.get_xticklabels()
+            + ax.get_yticklabels()
+        ):
+            item.set_fontsize(fontsize)
+
     if output_file is not None:
-        figure = plt.gcf()
         figure.savefig(output_file, bbox_inches="tight")
         plt.close(figure)
         figure = None
@@ -551,7 +571,7 @@ def spikesplot(
         va="center",
         ha="left",
         color="gray",
-        size=4,
+        size=plt.rcParams['font.size'] * 0.5,
         bbox={
             "boxstyle": "round",
             "fc": "w",
@@ -644,7 +664,7 @@ def confoundplot(
 
     # Set 10 frame markers in X axis
     interval = max((ntsteps // 10, ntsteps // 5, 1))
-    xticks = list(range(0, ntsteps)[::interval])
+    xticks = list(np.arange(0, ntsteps)[::interval])
     ax_ts.set_xticks(xticks)
 
     if not hide_x:
@@ -657,20 +677,21 @@ def confoundplot(
     else:
         ax_ts.set_xticklabels([])
 
+    fontsize = plt.rcParams['font.size']
     if name is not None:
         if units is not None:
             name += f" [{units}]"
 
         ax_ts.annotate(
             name,
-            xy=(0.0, 0.7),
+            xy=(0.0, 0.2),
             xytext=(0, 0),
             xycoords="axes fraction",
             textcoords="offset points",
-            va="center",
+            va="top",
             ha="left",
             color=color,
-            size=8,
+            size=fontsize * 0.45,
             bbox={
                 "boxstyle": "round",
                 "fc": "w",
@@ -734,14 +755,14 @@ def confoundplot(
     )
     ax_ts.annotate(
         stats_label,
-        xy=(0.98, 0.7),
+        xy=(0.98, 0.1),
         xycoords="axes fraction",
         xytext=(0, 0),
         textcoords="offset points",
-        va="center",
+        va="top",
         ha="right",
         color=color,
-        size=4,
+        size=fontsize * 0.5,
         bbox={
             "boxstyle": "round",
             "fc": "w",
@@ -762,7 +783,7 @@ def confoundplot(
         va="center",
         ha="right",
         color="lightgray",
-        size=3,
+        size=fontsize * 0.4,
     )
 
     if cutoff is None:
@@ -779,7 +800,7 @@ def confoundplot(
             va="center",
             ha="right",
             color="dimgray",
-            size=3,
+            size=fontsize * 0.4,
         )
 
     ax_ts.plot(tseries, color=color, linewidth=0.8)

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -326,7 +326,7 @@ def plot_carpet(
     if subplot is None:
         figure, allaxes = plt.subplots(figsize=(19.2, 10))
         allaxes.spines[:].set_visible(False)
-        allaxes.spines[:].set_color('none')
+        allaxes.spines[:].set_color("none")
         allaxes.get_xaxis().set_visible(False)
         allaxes.get_yaxis().set_visible(False)
         subplot = allaxes.get_subplotspec()
@@ -441,15 +441,9 @@ def plot_carpet(
         )
 
     if fontsize is not None:
-        ax.xaxis.label.set_fontsize(
-            max(8, fontsize * 0.75)
-        )
+        ax.xaxis.label.set_fontsize(max(8, fontsize * 0.75))
         # Change font size according to figure size
-        for item in (
-            [ax.title, ax.yaxis.label]
-            + ax.get_xticklabels()
-            + ax.get_yticklabels()
-        ):
+        for item in [ax.title, ax.yaxis.label] + ax.get_xticklabels() + ax.get_yticklabels():
             item.set_fontsize(fontsize)
 
     if output_file is not None:
@@ -571,7 +565,7 @@ def spikesplot(
         va="center",
         ha="left",
         color="gray",
-        size=plt.rcParams['font.size'] * 0.5,
+        size=plt.rcParams["font.size"] * 0.5,
         bbox={
             "boxstyle": "round",
             "fc": "w",
@@ -677,7 +671,7 @@ def confoundplot(
     else:
         ax_ts.set_xticklabels([])
 
-    fontsize = plt.rcParams['font.size']
+    fontsize = plt.rcParams["font.size"]
     if name is not None:
         if units is not None:
             name += f" [{units}]"

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -213,6 +213,7 @@ def plot_qi2(x_grid, ref_pdf, fit_pdf, ref_data, cutoff_idx, out_file=None):
         out_file = op.abspath("qi2_plot.svg")
 
     fig.savefig(out_file, bbox_inches="tight", pad_inches=0, dpi=300)
+    plt.close(fig=fig)
     return out_file
 
 
@@ -340,7 +341,6 @@ def plot_carpet(
         height_ratios=[len(v) for v in segments.values()],
     )
 
-    label = ""
     for i, (_, indices) in enumerate(segments.items()):
         # Carpet plot
         ax = plt.subplot(gs[i])
@@ -397,7 +397,7 @@ def plot_carpet(
             ax.set_title(title)
 
     if nsegments == 1:
-        ax.set_ylabel(label)
+        ax.set_ylabel(list(segments.keys())[0])
 
     if legend:
         from matplotlib.patches import Patch

--- a/nireports/reportlets/surface.py
+++ b/nireports/reportlets/surface.py
@@ -158,7 +158,7 @@ def cifti_surfaces_plot(
 
     if output_file is not None:
         figure.savefig(output_file, bbox_inches="tight", dpi=400)
-        plt.close(figure)
+        figure.clf()
         return output_file
 
     return figure

--- a/nireports/reportlets/utils.py
+++ b/nireports/reportlets/utils.py
@@ -153,6 +153,7 @@ def svg2str(display_object, dpi=300):
     display_object.frame_axes.figure.savefig(
         image_buf, dpi=dpi, format="svg", facecolor="k", edgecolor="k"
     )
+    display_object.frame_axes.figure.clf()
     image_buf.seek(0)
     return image_buf.getvalue()
 

--- a/nireports/reportlets/xca.py
+++ b/nireports/reportlets/xca.py
@@ -367,9 +367,10 @@ def compcor_variance_plot(
             ax[m].spines[side].set_visible(False)
 
     if output_file is not None:
-        figure = plt.gcf()
-        figure.savefig(output_file, bbox_inches="tight")
-        plt.close(figure)
-        figure = None
+        if fig is None:
+            fig = plt.gcf()
+        fig.savefig(output_file, bbox_inches="tight")
+        fig.clf()
+        fig = None
         return output_file
     return ax

--- a/nireports/tests/test_dwi.py
+++ b/nireports/tests/test_dwi.py
@@ -58,6 +58,7 @@ def test_plot_dwi(tmp_path, testdata_path, outdir):
 
     if outdir is not None:
         plt.savefig(outdir / f"{stem}.svg", bbox_inches="tight")
+        plt.close(plt.gcf())
 
 
 @pytest.mark.parametrize(
@@ -77,6 +78,7 @@ def test_plot_gradients(tmp_path, testdata_path, dwi_btable, outdir):
 
     if outdir is not None:
         plt.savefig(outdir / f"{dwi_btable}.svg", bbox_inches="tight")
+        plt.close(plt.gcf())
 
 
 def test_plot_tissue_values(tmp_path):

--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -173,6 +173,7 @@ def test_fmriplot(input_files, testdata_path, outdir):
             outdir / f"fmriplot_{dtype}{has_seg}.svg",
             bbox_inches="tight",
         )
+        fig.clf()
 
 
 def test_plot_melodic_components(tmp_path, outdir):


### PR DESCRIPTION
At the same time, this PR ensures that all calls to ``plt.savefig()`` are followed by closing the figure.

Resolves: #129.
Closes: #130.