### PR TITLE
feat: Move SimpleShowMaskRPT from niworkflows

### DIFF
--- a/nireports/interfaces/reporting/masks.py
+++ b/nireports/interfaces/reporting/masks.py
@@ -1,0 +1,39 @@
+# Copyright The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+from nipype.interfaces.base import File
+
+from .base import ReportingInterface, SegmentationRC, _SVGReportCapableInputSpec
+
+
+class _SimpleShowMaskInputSpec(_SVGReportCapableInputSpec):
+    background_file = File(exists=True, mandatory=True, desc="file before")
+    mask_file = File(exists=True, mandatory=True, desc="file before")
+
+
+class SimpleShowMaskRPT(SegmentationRC, ReportingInterface):
+    input_spec = _SimpleShowMaskInputSpec
+
+    def _post_run_hook(self, runtime):
+        self._anat_file = self.inputs.background_file
+        self._mask_file = self.inputs.mask_file
+        self._seg_files = [self.inputs.mask_file]
+        self._masked = True
+
+        return super()._post_run_hook(runtime)

--- a/nireports/tests/test_interfaces.py
+++ b/nireports/tests/test_interfaces.py
@@ -26,8 +26,10 @@ import os
 from shutil import copy
 
 import nibabel as nb
+import nipype.pipeline.engine as pe
 import numpy as np
 import pytest
+from templateflow.api import get as get_template
 
 from nireports.interfaces.fmri import FMRISummary
 from nireports.interfaces.nuisance import (
@@ -35,6 +37,7 @@ from nireports.interfaces.nuisance import (
     ConfoundsCorrelationPlot,
     RaincloudPlot,
 )
+from nireports.interfaces.reporting.masks import SimpleShowMaskRPT
 from nireports.tests.utils import _generate_raincloud_random_data
 
 
@@ -139,3 +142,31 @@ def test_FMRISummary(testdata_path, tmp_path, outdir):
         from shutil import copy
 
         copy(result.outputs.out_file, outdir / "fmriplot_nipype.svg")
+
+
+def test_SimpleShowMaskRPT(tmp_path, outdir):
+    msk_rpt = pe.Node(
+        SimpleShowMaskRPT(
+            generate_report=True,
+            background_file=str(
+                get_template("OASIS30ANTs", resolution=1, desc=None, suffix="T1w")
+            ),
+            mask_file=str(
+                get_template(
+                    "OASIS30ANTs",
+                    resolution=1,
+                    desc="BrainCerebellumRegistration",
+                    suffix="mask",
+                )
+            ),
+        ),
+        name="mask_rpt",
+        base_dir=str(tmp_path),
+    )
+
+    result = msk_rpt.run()
+
+    if outdir is not None:
+        from shutil import copy
+
+        copy(result.outputs.out_report, outdir / "simpleshowmask.svg")


### PR DESCRIPTION
sdcflows uses this interface but is producing warnings that niworkflows reporting has been moved to nireports. Making that more true.