### PR TITLE
chore(types): Configure and run mypy checks in CI

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -150,3 +150,28 @@ jobs:
         # Remove once OIDC is set up
         with:
           password: ${{ secrets.PYPI_API_TOKEN }}
+
+  checks:
+    runs-on: 'ubuntu-latest'
+    continue-on-error: true
+    strategy:
+      matrix:
+        check: ['style', 'spellcheck', 'typecheck']
+
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install the latest version of uv
+        uses: astral-sh/setup-uv@v4
+      # Can remove this once there is a traits release that supports 3.13
+      - name: Set up Python 3.12
+        uses: actions/setup-python@v5
+        with:
+          python-version: 3.12
+      - name: Install tox
+        run: uv tool install tox --with=tox-uv
+      - name: Show tox config
+        run: tox c
+      - name: Show tox config (this call)
+        run: tox c -e ${{ matrix.check }}
+      - name: Run check
+        run: tox -e ${{ matrix.check }}

--- a/nireports/interfaces/reporting/registration.py
+++ b/nireports/interfaces/reporting/registration.py
@@ -30,6 +30,7 @@ from nipype.interfaces import freesurfer as fs
 from nipype.interfaces import fsl
 from nipype.interfaces.base import (
     File,
+    TraitedSpec,
     isdefined,
     traits,
 )
@@ -131,10 +132,9 @@ class ApplyXFMRPT(FLIRTRPT, fsl.ApplyXFM):
     output_spec = _FLIRTOutputSpecRPT
 
 
+_BBRegisterInputSpec: type[TraitedSpec] = fs.preprocess.BBRegisterInputSpec6
 if LooseVersion("0.0.0") < fs.Info.looseversion() < LooseVersion("6.0.0"):
     _BBRegisterInputSpec = fs.preprocess.BBRegisterInputSpec
-else:
-    _BBRegisterInputSpec = fs.preprocess.BBRegisterInputSpec6
 
 
 class _BBRegisterInputSpecRPT(nrb._SVGReportCapableInputSpec, _BBRegisterInputSpec):

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -214,7 +214,6 @@ module = [
   "nilearn.*",
   "templateflow.*",
   "bids.*",
-  "svgutils",
   "svgutils.*",
   "pylab",
   "mpl_toolkits.*",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -66,6 +66,14 @@ test = [
     "pytest-xdist >= 2.5",
     "sphinx >= 6",
 ]
+types = [
+    "pandas-stubs",
+    "scipy-stubs",
+    "types-jinja2",
+    "types-pyyaml",
+    "pytest",
+    "microsoft-python-type-stubs @ git+https://github.com/microsoft/python-type-stubs.git",
+]
 
 # Aliases
 docs = ["nireports[doc]"]
@@ -198,3 +206,19 @@ ignore-words-list = "objekt"
 ignore = [
   "W002",
 ]
+
+[[tool.mypy.overrides]]
+module = [
+  "nipype.*",
+  "seaborn",
+  "nilearn.*",
+  "templateflow.*",
+  "bids.*",
+  "svgutils",
+  "svgutils.*",
+  "pylab",
+  "mpl_toolkits.*",
+  "nitransforms.*",
+  "IPython.*",
+]
+ignore_missing_imports = true

--- a/tox.ini
+++ b/tox.ini
@@ -90,6 +90,15 @@ commands =
   ruff format
   ruff check --select ISC001
 
+[testenv:typecheck]
+description = "Run mypy type checking"
+labels = check
+deps =
+  mypy
+extras = types
+commands =
+  mypy nireports
+
 [testenv:spellcheck]
 description = Check spelling
 labels = check


### PR DESCRIPTION
As a relatively small package, this seemed like a good place to start. As we add type annotations, mypy will ensure that we do it correctly.

cc @jhlegarreta 