### PR TITLE
ENH: Avoid divide by zero warnings when normalizing DWI data

### DIFF
--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -488,7 +488,11 @@ def nii_to_carpetplot_data(
         if divide_by_b0:
             b0_data = nii_data[..., bvals == 0]
             bzero = np.mean(b0_data, -1)
-            nii_data = nii_data / bzero[..., np.newaxis]
+            nii_data = np.divide(
+                nii_data,
+                bzero[..., np.newaxis],
+                where=bzero[..., np.newaxis] != 0,
+            )
 
         if drop_b0:
             nii_data = nii_data[..., bvals > 0]


### PR DESCRIPTION
Avoid divide by zero warnings when normalizing the DWI data: perform the division only in foreground voxels.

Fixes:
```
  nireports/tests/test_dwi.py::test_nii_to_carpetplot_data
    /home/runner/work/nireports/nireports/nireports/reportlets/modality/dwi.py:491: RuntimeWarning: invalid value encountered in divide
      nii_data = nii_data / bzero[..., np.newaxis]
```

Raised for example in:
https://github.com/nipreps/nireports/actions/runs/12681153218/job/35344304375#step:12:339