### PR TITLE
ENH: Close figures in test explicitly

### DIFF
--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -27,6 +27,7 @@ import os
 from itertools import permutations
 from pathlib import Path
 
+import matplotlib.pyplot as plt
 import nibabel as nb
 import numpy as np
 import pandas as pd
@@ -126,6 +127,8 @@ def test_carpetplot(tr, sorting, outdir):
         else None,
         sort_rows=sorting,
     )
+
+    plt.close()
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Close figures in test explicitly: when the `output_file` argument is `None` the `plot_carpet` method does not close figures, and thus a warning is raised if the number of open figures exceeds a given value.

Fixes:
```
nireports/tests/test_reportlets.py::test_carpetplot[linkage-0.7]
  /home/runner/work/nireports/nireports/nireports/reportlets/nuisance.py:326:
   RuntimeWarning: More than 20 figures have been opened.
   Figures created through the pyplot interface (`matplotlib.pyplot.figure`)
   are retained until explicitly closed and may consume too much memory.
   (To control this warning, see the rcParam `figure.max_open_warning`).
   Consider using `matplotlib.pyplot.close()`.
      figure, allaxes = plt.subplots(figsize=(19.2, 10))
```

reported for example in:
https://github.com/nipreps/nireports/actions/runs/12681153218/job/35344304375#step:12:351