### PR TITLE
ENH: Catch warning when loaded text file contains no data in test

### DIFF
--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -24,6 +24,7 @@
 
 import contextlib
 import os
+import warnings
 from itertools import permutations
 from pathlib import Path
 
@@ -239,14 +240,20 @@ def test_plot_melodic_components(tmp_path, outdir):
         out_file=all_noise,
     )
     # run command with no noise components
-    plot_melodic_components(
-        str(melodic_dir),
-        in_fname,
-        tr=2.0,
-        report_mask=report_fname,
-        noise_components_file=nocomps_file,
-        out_file=no_noise,
-    )
+    with warnings.catch_warnings():
+        warnings.filterwarnings(
+            "ignore",
+            message="loadtxt: input contained no data",
+            category=UserWarning,
+        )
+        plot_melodic_components(
+            str(melodic_dir),
+            in_fname,
+            tr=2.0,
+            report_mask=report_fname,
+            noise_components_file=nocomps_file,
+            out_file=no_noise,
+        )
 
     # run command without noise components file
     plot_melodic_components(


### PR DESCRIPTION
Catch warning when loaded text file contains no data in test.

Fixes:
```
nireports/tests/test_reportlets.py::test_plot_melodic_components
  /home/runner/work/nireports/nireports/nireports/reportlets/xca.py:128:
   UserWarning: loadtxt: input contained no data:
    "/tmp/pytest-of-runner/pytest-0/popen-gw0/test_plot_melodic_components0/noise_none.csv"
    noise_components = np.loadtxt(noise_components_file, dtype=int, delimiter=",", ndmin=1)
```

raised for example in:
https://github.com/nipreps/nireports/actions/runs/12681153218/job/35344304375#step:12:347