### PR TITLE
MAINT: Consider warnings as errors when running `pytest`

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -31,6 +31,7 @@ env:
   # Force tox and pytest to use color
   FORCE_COLOR: true
   TEMPLATEFLOW_HOME: /tmp/templateflow
+  NIREPORTS_WERRORS: 1
 
 jobs:
   build:

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -1104,8 +1104,8 @@ def plot_raincloud(
 
     df = pd.read_csv(data_file, sep=r"[\t\s]+", engine="python")
 
-    df_clip = df.copy(deep=True)
-    df_clip[feature] = df[feature].clip(lower=lower_limit_value, upper=upper_limit_value)
+    df_clip = pd.DataFrame(df, copy=True)
+    df_clip[feature] = df_clip[feature].clip(lower=lower_limit_value, upper=upper_limit_value)
 
     figure = figure if figure is not None else plt.figure(figsize=(7, 5))
     gs = GridSpec(1, 1)

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -1111,7 +1111,7 @@ def plot_raincloud(
     gs = GridSpec(1, 1)
     ax = plt.subplot(gs[0, 0])
 
-    sns.set(style="white", font_scale=2)
+    sns.set_theme(style="white", font_scale=2)
 
     x = feature
     y = group_name

--- a/tox.ini
+++ b/tox.ini
@@ -55,6 +55,7 @@ pass_env =
   CLICOLOR
   CLICOLOR_FORCE
   PYTHON_GIL
+  NIREPORTS_WERRORS
 extras = tests
 setenv =
   pre: PIP_EXTRA_INDEX_URL=https://pypi.anaconda.org/scientific-python-nightly-wheels/simple


### PR DESCRIPTION
Consider warnings as errors when running `pytest`.
