### PR TITLE
ENH: Copy NIfTI image header when creating from image

### DIFF
--- a/nireports/assembler/report.py
+++ b/nireports/assembler/report.py
@@ -285,7 +285,7 @@ class Report:
         }
         meta_repl.update({kk: vv for kk, vv in metadata.items() if isinstance(vv, str)})
         meta_repl.update(bids_filters)
-        expr = re.compile(f'{{({"|".join(meta_repl.keys())})}}')
+        expr = re.compile(f"{{({'|'.join(meta_repl.keys())})}}")
 
         for line in bootstrap_file.read_text().splitlines(keepends=False):
             if expr.search(line):

--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -80,7 +80,7 @@ def plot_dwi(dataobj, affine, gradient=None, **kwargs):
             if gradient is None
             else f"""\
 $b$={gradient[3].astype(int)}, \
-$\\vec{{b}}$ = ({', '.join(str(v) for v in gradient[:3])})"""
+$\\vec{{b}}$ = ({", ".join(str(v) for v in gradient[:3])})"""
         ),
         **kwargs,
     )

--- a/nireports/reportlets/mosaic.py
+++ b/nireports/reportlets/mosaic.py
@@ -35,12 +35,14 @@ from uuid import uuid4
 import matplotlib as mpl
 import matplotlib.pyplot as plt
 import nibabel as nb
+import nilearn
 import numpy as np
 import numpy.typing as npt
 from matplotlib.gridspec import GridSpec
 from nibabel.spatialimages import SpatialImage
 from nilearn import image as nlimage
 from nilearn.plotting import plot_anat
+from packaging.version import Version
 from svgutils.transform import SVGFigure, fromstring
 
 from nireports.reportlets.utils import (
@@ -89,7 +91,10 @@ def plot_segs(
     )
 
     if masked:
-        bbox_nii: SpatialImage = nlimage.threshold_img(bbox_nii, 1e-3)  # type: ignore[no-redef]
+        if Version(nilearn.__version__) >= Version("0.11"):
+            bbox_nii: SpatialImage = nlimage.threshold_img(bbox_nii, 1e-3, copy_header=True)  # type: ignore[no-redef]
+        else:
+            bbox_nii: SpatialImage = nlimage.threshold_img(bbox_nii, 1e-3)  # type: ignore[no-redef]
 
     cuts = cuts_from_bbox(bbox_nii, cuts=7)
     out_files = []


### PR DESCRIPTION
Copy the NIfTI image header of the primary source when creating another one from the former.

Make it conditional on the `nilearn` version as the warning is only being raised for `nilearn>=0.11`.

Fixes:
```
nireports/tests/test_interfaces_segmentation.py::test_SimpleShowMaskRPT
  /home/runner/work/nireports/nireports/nireports/reportlets/mosaic.py:92:
   FutureWarning: From release 0.13.0 onwards, this function will, by
   default, copy the header of the input image to the output. Currently,
   the header is reset to the default Nifti1Header. To suppress this
    warning and use the new behavior, set `copy_header=True`.
    bbox_nii: SpatialImage = nlimage.threshold_img(bbox_nii, 1e-3)  # type: ignore[no-redef]
```

raised for exmaple in:
https://github.com/nipreps/nireports/actions/runs/12681153218/job/35344304375#step:12:355