### PR TITLE
ENH: Fix mosaic plot `plot_sagittal` parameter warning

### DIFF
--- a/nireports/reportlets/mosaic.py
+++ b/nireports/reportlets/mosaic.py
@@ -553,7 +553,9 @@ def plot_mosaic(
 
     if plot_sagittal and views[1] is None and views[0] != "sagittal":
         warnings.warn(
-            "Argument ``plot_sagittal`` for plot_mosaic() should not be used.", stacklevel=2
+            "Argument ``plot_sagittal`` for plot_mosaic() should not be used.",
+            category=UserWarning,
+            stacklevel=2,
         )
         views = (views[0], "sagittal", None)
 


### PR DESCRIPTION
Fix mosaic plot `plot_sagittal` parameter warning: use a context manager to define the cases where errors or warnings are expected, and avoid the need for a partial function.

Fixes:
```
nireports/tests/test_reportlets.py::test_mriqc_plot_mosaic[True-views24]
nireports/tests/test_reportlets.py::test_mriqc_plot_mosaic[True-views26]
  /home/runner/work/nireports/nireports/nireports/tests/test_reportlets.py:360:
   UserWarning: Argument ``plot_sagittal`` for plot_mosaic() should not be used.
      testfunc()
```

raised for example in:
https://github.com/nipreps/nireports/actions/runs/12681153218/job/35344304375#step:12:360