### PR TITLE
DOC: Consider warnings as errors in documentation CI build

### DIFF
--- a/docs/make.bat
+++ b/docs/make.bat
@@ -9,6 +9,7 @@ if "%SPHINXBUILD%" == "" (
 )
 set SOURCEDIR=.
 set BUILDDIR=_build
+set SPHINXOPTS="-W --keep-going"
 
 %SPHINXBUILD% >NUL 2>NUL
 if errorlevel 9009 (


### PR DESCRIPTION
Consider warnings as errors in documentation CI build.