### PR TITLE
ENH: Close figures in test explicitly

### DIFF
--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -311,6 +311,8 @@ def test_cifti_carpetplot(tmp_path, test_data_package, outdir):
         cmap="paired",
     )
 
+    plt.close()
+
 
 def test_nifti_carpetplot(tmp_path, test_data_package, outdir):
     """Exercise extraction of timeseries from CIFTI2."""


### PR DESCRIPTION
Close figures in test explicitly: when the `output_file` argument is `None` the `plot_carpet` method does not close figures, and thus a warning is raised if the number of open figures exceeds a given value.

Fixes:
```
  nireports/tests/test_reportlets.py::test_cifti_carpetplot
    /home/runner/work/nireports/nireports/nireports/reportlets/nuisance.py:326:
 RuntimeWarning: More than 20 figures have been opened.
 Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are
 retained until explicitly closed and may consume too much memory.
 (To control this warning, see the rcParam `figure.max_open_warning`).
 Consider using `matplotlib.pyplot.close()`.
      figure, allaxes = plt.subplots(figsize=(19.2, 10))
```

raised for example in:
https://github.com/nipreps/nireports/actions/runs/13209372304/job/36879809365#step:14:337

Follow-up to commit 626dd35.