### PR TITLE
ENH: Fix `seaborn` and `matplotlib` orientation warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,10 @@ addopts = [
 ]
 doctest_optionflags = "ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS"
 env = "PYTHONHASHSEED=0"
-filterwarnings = ["ignore::DeprecationWarning"]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore:.*bool will be deprecated in a future version.*:PendingDeprecationWarning",
+]
 junit_family = "xunit2"
 
 


### PR DESCRIPTION
Fix `seaborn` and `matplotlib` orientation warning: `matplotlib` has deprecating the `vert` boolean orientation starting version 3.10.0. We are requiring `matplotlib` >= 3.5 and `seabornº >= 0.13.

`seaborn` supports `x` and `y` to specify the orientations starting version 0.13.0 and does an internal mapping to `matplotlib`'s `vertical` and `horizontal`:
https://github.com/mwaskom/seaborn/pull/3820/files#diff-42efb6918bd7e5f5a7b683aec2b32395b4ed303d3e2dae08f0e312171f7586ddR629

Map the `seaborn` `v` and `h` values to `x` and `y`, respectively, prior to calling the corresponding `seaborn` functions.

Fixes:
```
  nireports/tests/test_interfaces.py: 4 warnings
  nireports/tests/test_dwi.py: 1 warning
  nireports/tests/test_reportlets.py: 12 warnings
    /home/runner/work/nireports/nireports/.tox/py310-latest/lib/python3.10/site-packages/seaborn/categorical.py:700:
PendingDeprecationWarning: vert: bool will be deprecated in a future version.
 Use orientation: {'vertical', 'horizontal'} instead.
      artists = ax.bxp(**boxplot_kws)
```

raised for example in:
https://github.com/nipreps/nireports/actions/runs/13276183449/job/37066107605#step:14:336