### PR TITLE
ENH: Close all `Matplotlib` figures in relevant tests explicitly

### DIFF
--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -130,7 +130,7 @@ def test_carpetplot(tr, sorting, outdir):
         sort_rows=sorting,
     )
 
-    plt.close()
+    plt.close("all")
 
 
 @pytest.mark.parametrize(
@@ -320,7 +320,7 @@ def test_cifti_carpetplot(tmp_path, test_data_package, outdir):
         cmap="paired",
     )
 
-    plt.close()
+    plt.close("all")
 
 
 def test_nifti_carpetplot(tmp_path, test_data_package, outdir):
@@ -342,6 +342,8 @@ def test_nifti_carpetplot(tmp_path, test_data_package, outdir):
         output_file=outdir / "carpetplot_nifti.svg" if outdir is not None else None,
         drop_trs=0,
     )
+
+    plt.close("all")
 
 
 _views = list(permutations(("axial", "sagittal", "coronal", None), 3)) + [


### PR DESCRIPTION
Close all `Matplotlib` figures in relevant tests explicitly: when the `output_file` argument is `None` the `plot_carpet` method does not close figures, and thus a warning is raised if the number of open figures exceeds a given value.

Use `all` explicitly to guarantee all figures are closed. This change fixes the warnings that have persisted despite commits 626dd35 and 15f4898 claiming to fix these issues.

Fixes:
```
  nireports/tests/test_reportlets.py::test_nifti_carpetplot
    /home/runner/work/nireports/nireports/nireports/reportlets/nuisance.py:326:
 RuntimeWarning: More than 20 figures have been opened.
 Figures created through the pyplot interface (`matplotlib.pyplot.figure`) are
 retained until explicitly closed and may consume too much memory.
 (To control this warning, see the rcParam `figure.max_open_warning`).
 Consider using `matplotlib.pyplot.close()`.
      figure, allaxes = plt.subplots(figsize=(19.2, 10))
```

and similar warnings.

Raised for example in:
https://github.com/nipreps/nireports/actions/runs/13276183449/job/37066107605#step:14:341