### PR TITLE
ENH: Use a fixture to close `Matplotlib` figures in tests

### DIFF
--- a/nireports/tests/conftest.py
+++ b/nireports/tests/conftest.py
@@ -24,6 +24,7 @@
 
 import os
 
+import matplotlib.pyplot as plt
 import pytest
 from templateflow.api import get as get_template
 
@@ -57,3 +58,10 @@ def nthreads():
 
     # Tests are linear, so don't worry about leaving space for a control thread
     return min(int(getenv("CIRCLE_NPROCS", "8")), cpu_count())
+
+
+@pytest.fixture(autouse=True)
+def close_mpl_figures():
+    """Automatically close all Matplotlib figures after each test."""
+    yield
+    plt.close("all")

--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -28,7 +28,6 @@ import warnings
 from itertools import permutations
 from pathlib import Path
 
-import matplotlib.pyplot as plt
 import nibabel as nb
 import numpy as np
 import pandas as pd
@@ -129,8 +128,6 @@ def test_carpetplot(tr, sorting, outdir):
         else None,
         sort_rows=sorting,
     )
-
-    plt.close("all")
 
 
 @pytest.mark.parametrize(
@@ -320,8 +317,6 @@ def test_cifti_carpetplot(tmp_path, test_data_package, outdir):
         cmap="paired",
     )
 
-    plt.close("all")
-
 
 def test_nifti_carpetplot(tmp_path, test_data_package, outdir):
     """Exercise extraction of timeseries from CIFTI2."""
@@ -342,8 +337,6 @@ def test_nifti_carpetplot(tmp_path, test_data_package, outdir):
         output_file=outdir / "carpetplot_nifti.svg" if outdir is not None else None,
         drop_trs=0,
     )
-
-    plt.close("all")
 
 
 _views = list(permutations(("axial", "sagittal", "coronal", None), 3)) + [


### PR DESCRIPTION
Use a fixture to close `Matplotlib` figures in tests.

Resolves #168.