### PR TITLE
MAINT: Ignore `svgutils` regex warning

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -178,7 +178,10 @@ addopts = [
 ]
 doctest_optionflags = "ALLOW_UNICODE NORMALIZE_WHITESPACE ELLIPSIS"
 env = "PYTHONHASHSEED=0"
-filterwarnings = ["ignore::DeprecationWarning"]
+filterwarnings = [
+    "ignore::DeprecationWarning",
+    "ignore:.*invalid escape sequence.*:SyntaxWarning",
+]
 junit_family = "xunit2"
 
 


### PR DESCRIPTION
Ignore `svgutils` regex warning: the package is at its most recent release (0.3.4), and last commit was 3 years ago.

Fixes:
```
 .tox/py312-latest/lib/python3.12/site-packages/svgutils/compose.py:379
    /lib/python3.12/site-packages/svgutils/compose.py:379:
 SyntaxWarning: invalid escape sequence '\.'
      m = re.match("([0-9]+\.?[0-9]*)([a-z]+)", measure)
```

raised for example in:
https://github.com/nipreps/nireports/actions/runs/13355051658/job/37296638147?pr=169#step:14:337