### PR TITLE
rf: Vendor svgutils into nireports._vendored

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -53,7 +53,6 @@ autodoc_mock_imports = [
     "pandas",
     "seaborn",
     "skimage",
-    "svgutils",
     "templateflow",
     "transforms3d",
     "yaml",

--- a/nireports/_vendored/LICENSES/LICENSE.svgutils.txt
+++ b/nireports/_vendored/LICENSES/LICENSE.svgutils.txt
@@ -1,0 +1,19 @@
+Copyright (C) 2011 by Bartosz Telenczuk
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+THE SOFTWARE.

--- a/nireports/_vendored/svgutils/__init__.py
+++ b/nireports/_vendored/svgutils/__init__.py
@@ -1,0 +1,1 @@
+from . import compose, transform

--- a/nireports/_vendored/svgutils/common.py
+++ b/nireports/_vendored/svgutils/common.py
@@ -41,10 +41,10 @@ class Unit:
         return u
 
     def __str__(self):
-        return "{}{}".format(self.value, self.unit)
+        return f"{self.value}{self.unit}"
 
     def __repr__(self):
-        return "Unit({})".format(str(self))
+        return f"Unit({self})"
 
     def __mul__(self, number):
         u = Unit("0cm")

--- a/nireports/_vendored/svgutils/common.py
+++ b/nireports/_vendored/svgutils/common.py
@@ -1,0 +1,59 @@
+import re
+
+
+class Unit:
+    """Implementation of SVG units and conversions between them.
+
+    Parameters
+    ----------
+    measure : str
+        value with unit (for example, '2cm')
+    """
+
+    per_inch = {"px": 90, "cm": 2.54, "mm": 25.4, "pt": 72.0}
+
+    def __init__(self, measure):
+        try:
+            self.value = float(measure)
+            self.unit = "px"
+        except ValueError:
+            m = re.match(r"([0-9]+\.?[0-9]*)([a-z]+)", measure)
+            value, unit = m.groups()
+            self.value = float(value)
+            self.unit = unit
+
+    def to(self, unit):
+        """Convert to a given unit.
+
+        Parameters
+        ----------
+        unit : str
+           Name of the unit to convert to.
+
+        Returns
+        -------
+        u : Unit
+            new Unit object with the requested unit and computed value.
+        """
+        u = Unit("0cm")
+        u.value = self.value / self.per_inch[self.unit] * self.per_inch[unit]
+        u.unit = unit
+        return u
+
+    def __str__(self):
+        return "{}{}".format(self.value, self.unit)
+
+    def __repr__(self):
+        return "Unit({})".format(str(self))
+
+    def __mul__(self, number):
+        u = Unit("0cm")
+        u.value = self.value * number
+        u.unit = self.unit
+        return u
+
+    def __truediv__(self, number):
+        return self * (1.0 / number)
+
+    def __div__(self, number):
+        return self * (1.0 / number)

--- a/nireports/_vendored/svgutils/compose.py
+++ b/nireports/_vendored/svgutils/compose.py
@@ -43,7 +43,7 @@ class Element(_transform.FigureElement):
             pivot coordinates in user coordinate system (defaults to top-left
             corner of the figure)
         """
-        super(Element, self).rotate(angle, x, y)
+        super().rotate(angle, x, y)
         return self
 
     def move(self, x, y):
@@ -115,7 +115,7 @@ class SVG(Element):
             if fix_mpl:
                 w, h = svg.get_size()
                 svg.set_size((w.replace("pt", ""), h.replace("pt", "")))
-            super(SVG, self).__init__(svg.getroot().root)
+            super().__init__(svg.getroot().root)
 
             # if height/width is in % units, we can't store the absolute values
             if svg.width.endswith("%"):

--- a/nireports/_vendored/svgutils/compose.py
+++ b/nireports/_vendored/svgutils/compose.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding=utf-8
 """SVG definitions designed for easy SVG composing
 
 Features:

--- a/nireports/_vendored/svgutils/compose.py
+++ b/nireports/_vendored/svgutils/compose.py
@@ -1,0 +1,360 @@
+#!/usr/bin/env python3
+# coding=utf-8
+"""SVG definitions designed for easy SVG composing
+
+Features:
+    * allow for wildcard import
+    * defines a mini language for SVG composing
+    * short but readable names
+    * easy nesting
+    * method chaining
+    * no boilerplate code (reading files, extracting objects from svg,
+                           transversing XML tree)
+    * universal methods applicable to all element types
+    * don't have to learn python
+"""
+
+import os
+
+from . import transform as _transform
+from .common import Unit
+
+CONFIG = {
+    "svg.file_path": ".",
+    "figure.save_path": ".",
+    "image.file_path": ".",
+    "text.position": (0, 0),
+    "text.size": 8,
+    "text.weight": "normal",
+    "text.font": "Verdana",
+}
+
+
+class Element(_transform.FigureElement):
+    """Base class for new SVG elements."""
+
+    def rotate(self, angle, x=0, y=0):
+        """Rotate element by given angle around given pivot.
+
+        Parameters
+        ----------
+        angle : float
+            rotation angle in degrees
+        x, y : float
+            pivot coordinates in user coordinate system (defaults to top-left
+            corner of the figure)
+        """
+        super(Element, self).rotate(angle, x, y)
+        return self
+
+    def move(self, x, y):
+        """Move the element by x, y.
+
+        Parameters
+        ----------
+        x,y : int, str
+           amount of horizontal and vertical shift
+
+        Notes
+        -----
+        The x, y can be given with a unit (for example, "3px",  "5cm"). If no
+        unit is given the user unit is assumed ("px"). In SVG all units are
+        defined in relation to the user unit [1]_.
+
+        .. [1] W3C SVG specification:
+           https://www.w3.org/TR/SVG/coords.html#Units
+        """
+        self.moveto(x, y)
+        return self
+
+    def find_id(self, element_id):
+        """Find a single element with the given ID.
+
+        Parameters
+        ----------
+        element_id : str
+            ID of the element to find
+
+        Returns
+        -------
+        found element
+        """
+        element = _transform.FigureElement.find_id(self, element_id)
+        return Element(element.root)
+
+    def find_ids(self, element_ids):
+        """Find elements with given IDs.
+
+        Parameters
+        ----------
+        element_ids : list of strings
+            list of IDs to find
+
+        Returns
+        -------
+        a new `Panel` object which contains all the found elements.
+        """
+        elements = [_transform.FigureElement.find_id(self, eid) for eid in element_ids]
+        return Panel(*elements)
+
+
+class SVG(Element):
+    """SVG from file.
+
+    Parameters
+    ----------
+    fname : str
+       full path to the file
+    fix_mpl : bool
+        replace pt units with px units to fix files created with matplotlib
+    """
+
+    def __init__(self, fname=None, fix_mpl=False):
+        if fname:
+            fname = os.path.join(CONFIG["svg.file_path"], fname)
+            svg = _transform.fromfile(fname)
+            if fix_mpl:
+                w, h = svg.get_size()
+                svg.set_size((w.replace("pt", ""), h.replace("pt", "")))
+            super(SVG, self).__init__(svg.getroot().root)
+
+            # if height/width is in % units, we can't store the absolute values
+            if svg.width.endswith("%"):
+                self._width = None
+            else:
+                self._width = Unit(svg.width).to("px")
+            if svg.height.endswith("%"):
+                self._height = None
+            else:
+                self._height = Unit(svg.height).to("px")
+
+    @property
+    def width(self):
+        """Get width of the svg file in px"""
+        if self._width:
+            return self._width.value
+
+    @property
+    def height(self):
+        """Get height of the svg file in px"""
+        if self._height:
+            return self._height.value
+
+
+class MplFigure(SVG):
+    """Matplotlib figure
+
+    Parameters
+    ----------
+    fig : matplotlib Figure instance
+        instance of Figure to be converted
+    kws :
+        keyword arguments passed to matplotlib's savefig method
+    """
+
+    def __init__(self, fig, **kws):
+        svg = _transform.from_mpl(fig, savefig_kw=kws)
+        self.root = svg.getroot().root
+
+
+class Image(Element):
+    """Raster or vector image
+
+    Parameters
+    ----------
+    width : float
+    height : float
+        image dimensions
+    fname : str
+        full path to the file
+    """
+
+    def __init__(self, width, height, fname):
+        fname = os.path.join(CONFIG["image.file_path"], fname)
+        _, fmt = os.path.splitext(fname)
+        fmt = fmt.lower()[1:]
+        with open(fname, "rb") as fid:
+            img = _transform.ImageElement(fid, width, height, fmt)
+        self.root = img.root
+
+
+class Text(Element):
+    """Text element.
+
+    Parameters
+    ----------
+    text : str
+       content
+    x, y : float or str
+       Text position. If unit is not given it will assume user units (px).
+    size : float, optional
+       Font size.
+    weight : str, optional
+       Font weight. It can be one of: normal, bold, bolder or lighter.
+    font : str, optional
+       Font family.
+    """
+
+    def __init__(self, text, x=None, y=None, **kwargs):
+        params = {
+            "size": CONFIG["text.size"],
+            "weight": CONFIG["text.weight"],
+            "font": CONFIG["text.font"],
+        }
+        if x is None or y is None:
+            x, y = CONFIG["text.position"]
+        params.update(kwargs)
+        element = _transform.TextElement(x, y, text, **params)
+        Element.__init__(self, element.root)
+
+
+class Panel(Element):
+    """Figure panel.
+
+    Panel is a group of elements that can be transformed together. Usually
+    it relates to a labeled figure panel.
+
+    Parameters
+    ----------
+    svgelements : objects deriving from Element class
+        one or more elements that compose the panel
+
+    Notes
+    -----
+    The grouped elements need to be properly arranged in scale and position.
+    """
+
+    def __init__(self, *svgelements):
+        element = _transform.GroupElement(svgelements)
+        Element.__init__(self, element.root)
+
+    def __iter__(self):
+        elements = self.root.getchildren()
+        return (Element(el) for el in elements)
+
+
+class Line(Element):
+    """Line element connecting given points.
+
+    Parameters
+    ----------
+    points : sequence of tuples
+        List of point x,y coordinates.
+    width : float, optional
+        Line width.
+    color : str, optional
+        Line color. Any of the HTML/CSS color definitions are allowed.
+    """
+
+    def __init__(self, points, width=1, color="black"):
+        element = _transform.LineElement(points, width=width, color=color)
+        Element.__init__(self, element.root)
+
+
+class Grid(Element):
+    """Line grid with coordinate labels to facilitate placement of new
+    elements.
+
+    Parameters
+    ----------
+    dx : float
+       Spacing between the vertical lines.
+    dy : float
+       Spacing between horizontal lines.
+    size : float or str
+       Font size of the labels.
+
+    Notes
+    -----
+    This element is mainly useful for manual placement of the elements.
+    """
+
+    def __init__(self, dx, dy, size=8):
+        self.size = size
+        lines = self._gen_grid(dx, dy)
+        element = _transform.GroupElement(lines)
+        Element.__init__(self, element.root)
+
+    def _gen_grid(self, dx, dy, width=0.5):
+        xmax, ymax = 1000, 1000
+        x, y = 0, 0
+        lines = []
+        txt = []
+        while x < xmax:
+            lines.append(_transform.LineElement([(x, 0), (x, ymax)], width=width))
+            txt.append(_transform.TextElement(x, dy / 2, str(x), size=self.size))
+            x += dx
+        while y < ymax:
+            lines.append(_transform.LineElement([(0, y), (xmax, y)], width=width))
+            txt.append(_transform.TextElement(0, y, str(y), size=self.size))
+            y += dy
+        return lines + txt
+
+
+class Figure(Panel):
+    """Main figure class.
+
+    This should be always the top class of all the generated SVG figures.
+
+    Parameters
+    ----------
+    width, height : float or str
+        Figure size. If unit is not given, user units (px) are assumed.
+    """
+
+    def __init__(self, width, height, *svgelements):
+        Panel.__init__(self, *svgelements)
+        self.width = Unit(width)
+        self.height = Unit(height)
+
+    def save(self, fname):
+        """Save figure to SVG file.
+
+        Parameters
+        ----------
+        fname : str
+            Full path to file.
+        """
+        element = _transform.SVGFigure(self.width, self.height)
+        element.append(self)
+        element.save(os.path.join(CONFIG["figure.save_path"], fname))
+
+    def tostr(self):
+        """Export SVG as a string"""
+        element = _transform.SVGFigure(self.width, self.height)
+        element.append(self)
+        svgstr = element.to_str()
+        return svgstr
+
+    def _repr_svg_(self):
+        return self.tostr().decode("ascii")
+
+    def tile(self, ncols, nrows):
+        """Automatically tile the panels of the figure.
+
+        This will re-arranged all elements of the figure (first in the
+        hierarchy) so that they will uniformly cover the figure area.
+
+        Parameters
+        ----------
+        ncols, nrows : type
+            The number of columns and rows to arrange the elements into.
+
+
+        Notes
+        -----
+        ncols * nrows must be larger or equal to number of
+        elements, otherwise some elements will go outside the figure borders.
+        """
+        dx = (self.width / ncols).to("px").value
+        dy = (self.height / nrows).to("px").value
+        ix, iy = 0, 0
+        for el in self:
+            el.move(dx * ix, dy * iy)
+            ix += 1
+            if ix >= ncols:
+                ix = 0
+                iy += 1
+            if iy > nrows:
+                break
+        return self

--- a/nireports/_vendored/svgutils/templates.py
+++ b/nireports/_vendored/svgutils/templates.py
@@ -1,5 +1,4 @@
 #!/usr/bin/env python3
-# coding=utf-8
 
 from .transform import GroupElement, SVGFigure
 

--- a/nireports/_vendored/svgutils/templates.py
+++ b/nireports/_vendored/svgutils/templates.py
@@ -1,0 +1,74 @@
+#!/usr/bin/env python3
+# coding=utf-8
+
+from .transform import GroupElement, SVGFigure
+
+
+class BaseTemplate(SVGFigure):
+    def __init__(self):
+        SVGFigure.__init__(self)
+        self.figures = []
+
+    def add_figure(self, fig):
+        w, h = fig.get_size()
+        root = fig.getroot()
+        self.figures.append({"root": root, "width": w, "height": h})
+
+    def _transform(self):
+        pass
+
+    def save(self, fname):
+        self._generate_layout()
+        SVGFigure.save(self, fname)
+
+    def _generate_layout(self):
+        for i, f in enumerate(self.figures):
+            new_element = self._transform(f["root"], self.figures[:i])
+            self.append(new_element)
+
+
+class VerticalLayout(BaseTemplate):
+    def _transform(self, element, transform_list):
+        for t in transform_list:
+            element = GroupElement([element])
+            element.moveto(0, t["height"])
+        return element
+
+
+class ColumnLayout(BaseTemplate):
+    def __init__(self, nrows, row_height=None, col_width=None):
+        """Multiple column layout with nrows and required number of
+        columns. col_width
+        determines the width of the column (defaults to width of the
+        first added element)"""
+
+        self.nrows = nrows
+        self.col_width = col_width
+        self.row_height = row_height
+
+        BaseTemplate.__init__(self)
+
+    def _transform(self, element, transform_list):
+        rows = 0
+
+        if not transform_list:
+            return element
+
+        n_elements = len(transform_list)
+        rows = n_elements % self.nrows
+        cols = int(n_elements / self.nrows)
+
+        if self.col_width is None:
+            self.col_width = transform_list[0]["width"]
+        if self.row_height is None:
+            self.row_height = transform_list[0]["height"]
+
+        for i in range(rows):
+            element = GroupElement([element])
+            element.moveto(0, self.row_height)
+
+        for i in range(cols):
+            element = GroupElement([element])
+            element.moveto(self.col_width, 0)
+
+        return element

--- a/nireports/_vendored/svgutils/templates.py
+++ b/nireports/_vendored/svgutils/templates.py
@@ -63,11 +63,11 @@ class ColumnLayout(BaseTemplate):
         if self.row_height is None:
             self.row_height = transform_list[0]["height"]
 
-        for i in range(rows):
+        for _ in range(rows):
             element = GroupElement([element])
             element.moveto(0, self.row_height)
 
-        for i in range(cols):
+        for _ in range(cols):
             element = GroupElement([element])
             element.moveto(self.col_width, 0)
 

--- a/nireports/_vendored/svgutils/transform.py
+++ b/nireports/_vendored/svgutils/transform.py
@@ -17,7 +17,7 @@ XLINK = "{%s}" % XLINK_NAMESPACE
 NSMAP = {None: SVG_NAMESPACE, "xlink": XLINK_NAMESPACE}
 
 
-class FigureElement(object):
+class FigureElement:
     """Base class representing single figure element"""
 
     def __init__(self, xml_element, defs=None):
@@ -223,7 +223,7 @@ class GroupElement(FigureElement):
         self.root = new_group
 
 
-class SVGFigure(object):
+class SVGFigure:
     """SVG Figure.
 
     It setups standalone SVG tree. It corresponds to SVG ``<svg>`` tag.

--- a/nireports/_vendored/svgutils/transform.py
+++ b/nireports/_vendored/svgutils/transform.py
@@ -12,8 +12,8 @@ from .common import Unit
 
 SVG_NAMESPACE = "http://www.w3.org/2000/svg"
 XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
-SVG = "{%s}" % SVG_NAMESPACE
-XLINK = "{%s}" % XLINK_NAMESPACE
+SVG = f"{{{SVG_NAMESPACE}}}"
+XLINK = f"{{{XLINK_NAMESPACE}}}"
 NSMAP = {None: SVG_NAMESPACE, "xlink": XLINK_NAMESPACE}
 
 
@@ -253,7 +253,7 @@ class SVGFigure:
             value = Unit(value)
         self._width = value.value
         self.root.set("width", str(value))
-        self.root.set("viewBox", "0 0 %s %s" % (self._width, self._height))
+        self.root.set("viewBox", f"0 0 {self._width} {self._height}")
 
     @property
     def height(self):
@@ -266,7 +266,7 @@ class SVGFigure:
             value = Unit(value)
         self._height = value.value
         self.root.set("height", str(value))
-        self.root.set("viewBox", "0 0 %s %s" % (self._width, self._height))
+        self.root.set("viewBox", f"0 0 {self._width} {self._height}")
 
     def append(self, element):
         """Append new element to the SVG figure"""

--- a/nireports/_vendored/svgutils/transform.py
+++ b/nireports/_vendored/svgutils/transform.py
@@ -200,7 +200,7 @@ class LineElement(FigureElement):
 
     def __init__(self, points, width=1, color="black"):
         linedata = "M{} {} ".format(*points[0])
-        linedata += " ".join(map(lambda x: "L{} {}".format(*x), points[1:]))
+        linedata += " ".join("L{} {}".format(*x) for x in points[1:])
         line = etree.Element(
             SVG + "path", {"d": linedata, "stroke-width": str(width), "stroke": color}
         )
@@ -416,8 +416,8 @@ def from_mpl(fig, savefig_kw=None):
 
     try:
         fig.savefig(fid, format="svg", **savefig_kw)
-    except ValueError:
-        raise (ValueError, "No matplotlib SVG backend")
+    except ValueError as e:
+        raise ValueError("No matplotlib SVG backend") from e
     fid.seek(0)
     fig = fromstring(fid.read())
 

--- a/nireports/_vendored/svgutils/transform.py
+++ b/nireports/_vendored/svgutils/transform.py
@@ -1,12 +1,8 @@
 import codecs
 from copy import deepcopy
+from io import StringIO
 
 from lxml import etree
-
-try:
-    from StringIO import StringIO
-except ImportError:
-    from io import StringIO
 
 from .common import Unit
 

--- a/nireports/_vendored/svgutils/transform.py
+++ b/nireports/_vendored/svgutils/transform.py
@@ -1,0 +1,428 @@
+import codecs
+from copy import deepcopy
+
+from lxml import etree
+
+try:
+    from StringIO import StringIO
+except ImportError:
+    from io import StringIO
+
+from .common import Unit
+
+SVG_NAMESPACE = "http://www.w3.org/2000/svg"
+XLINK_NAMESPACE = "http://www.w3.org/1999/xlink"
+SVG = "{%s}" % SVG_NAMESPACE
+XLINK = "{%s}" % XLINK_NAMESPACE
+NSMAP = {None: SVG_NAMESPACE, "xlink": XLINK_NAMESPACE}
+
+
+class FigureElement(object):
+    """Base class representing single figure element"""
+
+    def __init__(self, xml_element, defs=None):
+        self.root = xml_element
+
+    def moveto(self, x, y, scale_x=1, scale_y=None):
+        """Move and scale element.
+
+        Parameters
+        ----------
+        x, y : float
+             displacement in x and y coordinates in user units ('px').
+        scale_x : float
+             x-direction scaling factor. To scale down scale_x < 1,  scale up scale_x > 1.
+        scale_y : (optional) float
+             y-direction scaling factor. To scale down scale_y < 1,  scale up scale_y > 1.
+             If set to default (None), then scale_y=scale_x.
+        """
+        if scale_y is None:
+            scale_y = scale_x
+        self.root.set(
+            "transform",
+            "translate(%s, %s) scale(%s %s) %s"
+            % (x, y, scale_x, scale_y, self.root.get("transform") or ""),
+        )
+
+    def rotate(self, angle, x=0, y=0):
+        """Rotate element by given angle around given pivot.
+
+        Parameters
+        ----------
+        angle : float
+            rotation angle in degrees
+        x, y : float
+            pivot coordinates in user coordinate system (defaults to top-left
+            corner of the figure)
+        """
+        self.root.set(
+            "transform",
+            "%s rotate(%f %f %f)" % (self.root.get("transform") or "", angle, x, y),
+        )
+
+    def skew(self, x=0, y=0):
+        """Skew the element by x and y degrees
+        Convenience function which calls skew_x and skew_y
+
+        Parameters
+        ----------
+        x,y : float, float
+            skew angle in degrees (default 0)
+
+            If an x/y angle is given as zero degrees, that transformation is omitted.
+        """
+        if x != 0:
+            self.skew_x(x)
+        if y != 0:
+            self.skew_y(y)
+
+        return self
+
+    def skew_x(self, x):
+        """Skew element along the x-axis by the given angle.
+
+        Parameters
+        ----------
+        x : float
+            x-axis skew angle in degrees
+        """
+        self.root.set("transform", "%s skewX(%f)" % (self.root.get("transform") or "", x))
+        return self
+
+    def skew_y(self, y):
+        """Skew element along the y-axis by the given angle.
+
+        Parameters
+        ----------
+        y : float
+            y-axis skew angle in degrees
+        """
+        self.root.set("transform", "%s skewY(%f)" % (self.root.get("transform") or "", y))
+        return self
+
+    def scale(self, x=0, y=None):
+        """Scale element separately across the two axes x and y.
+            If y is not provided, it is assumed equal to x (according to the
+            W3 specification).
+
+        Parameters
+        ----------
+        x : float
+            x-axis scaling factor. To scale down x < 1, scale up x > 1.
+        y : (optional) float
+            y-axis scaling factor. To scale down y < 1, scale up y > 1.
+
+        """
+        self.moveto(0, 0, x, y)
+        return self
+
+    def __getitem__(self, i):
+        return FigureElement(self.root.getchildren()[i])
+
+    def copy(self):
+        """Make a copy of the element"""
+        return deepcopy(self.root)
+
+    def tostr(self):
+        """String representation of the element"""
+        return etree.tostring(self.root, pretty_print=True)
+
+    def find_id(self, element_id):
+        """Find element by its id.
+
+        Parameters
+        ----------
+        element_id : str
+            ID of the element to find
+
+        Returns
+        -------
+        FigureElement
+            one of the children element with the given ID."""
+        find = etree.XPath("//*[@id=$id]")
+        return FigureElement(find(self.root, id=element_id)[0])
+
+
+class TextElement(FigureElement):
+    """Text element.
+
+    Corresponds to SVG ``<text>`` tag."""
+
+    def __init__(
+        self,
+        x,
+        y,
+        text,
+        size=8,
+        font="Verdana",
+        weight="normal",
+        letterspacing=0,
+        anchor="start",
+        color="black",
+    ):
+        txt = etree.Element(
+            SVG + "text",
+            {
+                "x": str(x),
+                "y": str(y),
+                "font-size": str(size),
+                "font-family": font,
+                "font-weight": weight,
+                "letter-spacing": str(letterspacing),
+                "text-anchor": str(anchor),
+                "fill": str(color),
+            },
+        )
+        txt.text = text
+        FigureElement.__init__(self, txt)
+
+
+class ImageElement(FigureElement):
+    """Inline image element.
+
+    Correspoonds to SVG ``<image>`` tag. Image data encoded as base64 string.
+    """
+
+    def __init__(self, stream, width, height, format="png"):
+        base64str = codecs.encode(stream.read(), "base64").rstrip()
+        uri = "data:image/{};base64,{}".format(format, base64str.decode("ascii"))
+        attrs = {"width": str(width), "height": str(height), XLINK + "href": uri}
+        img = etree.Element(SVG + "image", attrs)
+        FigureElement.__init__(self, img)
+
+
+class LineElement(FigureElement):
+    """Line element.
+
+    Corresponds to SVG ``<path>`` tag. It handles only piecewise
+    straight segments
+    """
+
+    def __init__(self, points, width=1, color="black"):
+        linedata = "M{} {} ".format(*points[0])
+        linedata += " ".join(map(lambda x: "L{} {}".format(*x), points[1:]))
+        line = etree.Element(
+            SVG + "path", {"d": linedata, "stroke-width": str(width), "stroke": color}
+        )
+        FigureElement.__init__(self, line)
+
+
+class GroupElement(FigureElement):
+    """Group element.
+
+    Container for other elements. Corresponds to SVG ``<g>`` tag.
+    """
+
+    def __init__(self, element_list, attrib=None):
+        new_group = etree.Element(SVG + "g", attrib=attrib)
+        for e in element_list:
+            if isinstance(e, FigureElement):
+                new_group.append(e.root)
+            else:
+                new_group.append(e)
+        self.root = new_group
+
+
+class SVGFigure(object):
+    """SVG Figure.
+
+    It setups standalone SVG tree. It corresponds to SVG ``<svg>`` tag.
+    """
+
+    def __init__(self, width=None, height=None):
+        self.root = etree.Element(SVG + "svg", nsmap=NSMAP)
+        self.root.set("version", "1.1")
+
+        self._width = 0
+        self._height = 0
+
+        if width:
+            self.width = width  # this goes to @width.setter a few lines down
+
+        if height:
+            self.height = height  # this goes to @height.setter a few lines down
+
+    @property
+    def width(self):
+        """Figure width"""
+        return self.root.get("width")
+
+    @width.setter
+    def width(self, value):
+        if not isinstance(value, Unit):
+            value = Unit(value)
+        self._width = value.value
+        self.root.set("width", str(value))
+        self.root.set("viewBox", "0 0 %s %s" % (self._width, self._height))
+
+    @property
+    def height(self):
+        """Figure height"""
+        return self.root.get("height")
+
+    @height.setter
+    def height(self, value):
+        if not isinstance(value, Unit):
+            value = Unit(value)
+        self._height = value.value
+        self.root.set("height", str(value))
+        self.root.set("viewBox", "0 0 %s %s" % (self._width, self._height))
+
+    def append(self, element):
+        """Append new element to the SVG figure"""
+        try:
+            self.root.append(element.root)
+        except AttributeError:
+            self.root.append(GroupElement(element).root)
+
+    def getroot(self):
+        """Return the root element of the figure.
+
+        The root element is a group of elements after stripping the toplevel
+        ``<svg>`` tag.
+
+        Returns
+        -------
+        GroupElement
+            All elements of the figure without the ``<svg>`` tag.
+        """
+        if "class" in self.root.attrib:
+            attrib = {"class": self.root.attrib["class"]}
+        else:
+            attrib = None
+        return GroupElement(self.root.getchildren(), attrib=attrib)
+
+    def to_str(self):
+        """
+        Returns a string of the SVG figure.
+        """
+        return etree.tostring(self.root, xml_declaration=True, standalone=True, pretty_print=True)
+
+    def save(self, fname, encoding=None):
+        """
+        Save figure to a file
+        Default encoding is "ASCII" when None is specified, as dictated by lxml .
+        """
+        out = etree.tostring(
+            self.root,
+            xml_declaration=True,
+            standalone=True,
+            pretty_print=True,
+            encoding=encoding,
+        )
+        with open(fname, "wb") as fid:
+            fid.write(out)
+
+    def find_id(self, element_id):
+        """Find elements with the given ID"""
+        find = etree.XPath("//*[@id=$id]")
+        return FigureElement(find(self.root, id=element_id)[0])
+
+    def get_size(self):
+        """Get figure size"""
+        return self.root.get("width"), self.root.get("height")
+
+    def set_size(self, size):
+        """Set figure size"""
+        w, h = size
+        self.root.set("width", w)
+        self.root.set("height", h)
+
+
+def fromfile(fname):
+    """Open SVG figure from file.
+
+    Parameters
+    ----------
+    fname : str
+        name of the SVG file
+
+    Returns
+    -------
+    SVGFigure
+        newly created :py:class:`SVGFigure` initialised with the file content
+    """
+    fig = SVGFigure()
+    with open(fname) as fid:
+        svg_file = etree.parse(fid, parser=etree.XMLParser(huge_tree=True))
+
+    fig.root = svg_file.getroot()
+    return fig
+
+
+def fromstring(text):
+    """Create a SVG figure from a string.
+
+    Parameters
+    ----------
+    text : str
+        string representing the SVG content. Must be valid SVG.
+
+    Returns
+    -------
+    SVGFigure
+        newly created :py:class:`SVGFigure` initialised with the string
+        content.
+    """
+    fig = SVGFigure()
+    svg = etree.fromstring(text.encode(), parser=etree.XMLParser(huge_tree=True))
+
+    fig.root = svg
+
+    return fig
+
+
+def from_mpl(fig, savefig_kw=None):
+    """Create a SVG figure from a ``matplotlib`` figure.
+
+    Parameters
+    ----------
+    fig : matplotlib.Figure instance
+
+    savefig_kw : dict
+         keyword arguments to be passed to matplotlib's
+         `savefig`
+
+
+
+    Returns
+    -------
+    SVGFigure
+        newly created :py:class:`SVGFigure` initialised with the string
+        content.
+
+
+    Examples
+    --------
+
+    If you want to overlay the figure on another SVG, you may want to pass
+    the `transparent` option:
+
+    >>> from nireports._vendored.svgutils import transform
+    >>> import matplotlib.pyplot as plt
+    >>> fig = plt.figure()
+    >>> line, = plt.plot([1,2])
+    >>> svgfig = transform.from_mpl(fig,
+    ...              savefig_kw=dict(transparent=True))
+    >>> svgfig.getroot()
+    <nireports._vendored.svgutils.transform.GroupElement object at ...>
+
+
+    """
+
+    fid = StringIO()
+    if savefig_kw is None:
+        savefig_kw = {}
+
+    try:
+        fig.savefig(fid, format="svg", **savefig_kw)
+    except ValueError:
+        raise (ValueError, "No matplotlib SVG backend")
+    fid.seek(0)
+    fig = fromstring(fid.read())
+
+    # workaround mpl units bug
+    w, h = fig.get_size()
+    fig.set_size((w.replace("pt", ""), h.replace("pt", "")))
+
+    return fig

--- a/nireports/_vendored/svgutils/transform.py
+++ b/nireports/_vendored/svgutils/transform.py
@@ -180,7 +180,7 @@ class TextElement(FigureElement):
 class ImageElement(FigureElement):
     """Inline image element.
 
-    Correspoonds to SVG ``<image>`` tag. Image data encoded as base64 string.
+    Corresponds to SVG ``<image>`` tag. Image data encoded as base64 string.
     """
 
     def __init__(self, stream, width, height, format="png"):

--- a/nireports/assembler/misc.py
+++ b/nireports/assembler/misc.py
@@ -146,7 +146,7 @@ def dict2html(indict, table_id):
 
     width = max(len(row) for row in rows)
 
-    result_str = '<table id="%s" class="table table-sm table-striped">\n' % table_id
+    result_str = f'<table id="{table_id}" class="table table-sm table-striped">\n'
     td = "<td{1}>{0}</td>".format
     for row in rows:
         result_str += "<tr>"

--- a/nireports/interfaces/mosaic.py
+++ b/nireports/interfaces/mosaic.py
@@ -88,7 +88,7 @@ class PlotContours(SimpleInterface):
             in_file_ref = Path(self.inputs.out_file)
 
         fname = in_file_ref.name.rstrip("".join(in_file_ref.suffixes))
-        out_file = (Path(runtime.cwd) / ("plot_%s_contours.svg" % fname)).resolve()
+        out_file = (Path(runtime.cwd) / (f"plot_{fname}_contours.svg")).resolve()
         self._results["out_file"] = str(out_file)
 
         vmax = None if not isdefined(self.inputs.vmax) else self.inputs.vmax

--- a/nireports/interfaces/reporting/masks.py
+++ b/nireports/interfaces/reporting/masks.py
@@ -135,7 +135,7 @@ class ACompCorRPT(nrb.SegmentationRC, confounds.ACompCor):
         if len(self.inputs.mask_files) != 1:
             raise ValueError(
                 "ACompCorRPT only supports a single input mask. "
-                "A list %s was found." % self.inputs.mask_files
+                f"A list {self.inputs.mask_files} was found."
             )
         self._anat_file = self.inputs.realigned_file
         self._mask_file = self.inputs.mask_files[0]
@@ -171,7 +171,7 @@ class TCompCorRPT(nrb.SegmentationRC, confounds.TCompCor):
         if isinstance(high_variance_masks, list):
             raise ValueError(
                 "TCompCorRPT only supports a single output high variance mask. "
-                "A list %s was found." % high_variance_masks
+                f"A list {high_variance_masks} was found."
             )
         self._anat_file = self.inputs.realigned_file
         self._mask_file = high_variance_masks

--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -588,7 +588,7 @@ def get_segment_labels(filepath, keywords, delimiter=" ", index_position=0, labe
     """
     segment_labels = {}
 
-    with open(filepath, "r") as f:
+    with open(filepath) as f:
         labels = f.read()
 
     labels_s = [label.split(delimiter) for label in labels.split("\n") if label != ""]

--- a/nireports/reportlets/mosaic.py
+++ b/nireports/reportlets/mosaic.py
@@ -43,8 +43,8 @@ from nibabel.spatialimages import SpatialImage
 from nilearn import image as nlimage
 from nilearn.plotting import plot_anat
 from packaging.version import Version
-from svgutils.transform import SVGFigure, fromstring
 
+from nireports._vendored.svgutils.transform import SVGFigure, fromstring
 from nireports.reportlets.utils import (
     _3d_in_file,
     _bbox,

--- a/nireports/reportlets/mosaic.py
+++ b/nireports/reportlets/mosaic.py
@@ -496,7 +496,7 @@ def plot_spikes(
         fname, ext = op.splitext(op.basename(in_file))
         if ext == ".gz":
             fname, _ = op.splitext(fname)
-        out_file = op.abspath("%s.svg" % fname)
+        out_file = op.abspath(f"{fname}.svg")
 
     fig.savefig(out_file, format="svg", dpi=300, bbox_inches="tight")
     return out_file

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -522,7 +522,7 @@ def spikesplot(
             ax.set_xlabel("time (frame #)")
         else:
             ax.set_xlabel("time (s)")
-            ax.set_xticklabels(["%.02f" % t for t in (tr * np.array(xticks)).tolist()])
+            ax.set_xticklabels([f"{t:.2f}" for t in (tr * np.array(xticks)).tolist()])
 
     # Handle Y axis
     ylabel = "slice-wise noise average on background"
@@ -754,7 +754,7 @@ def confoundplot(
     # Annotate percentile 95
     ax_ts.plot((0, ntsteps - 1), [p95] * 2, linewidth=0.1, color="lightgray")
     ax_ts.annotate(
-        "%.2f" % p95,
+        f"{p95:.2f}",
         xy=(0, p95),
         xytext=(-1, 0),
         textcoords="offset points",
@@ -771,7 +771,7 @@ def confoundplot(
         ax_ts.plot((0, ntsteps - 1), [thr] * 2, linewidth=0.2, color="dimgray")
 
         ax_ts.annotate(
-            "%.2f" % thr,
+            f"{thr:.2f}",
             xy=(0, thr),
             xytext=(-1, 0),
             textcoords="offset points",

--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -138,7 +138,7 @@ def _calc_rows_columns(ratio, n_images):
 def _calc_fd(fd_file, fd_radius):
     from math import pi
 
-    lines = open(fd_file, "r").readlines()
+    lines = open(fd_file).readlines()
     rows = [[float(x) for x in line.split()] for line in lines]
     cols = np.array([list(col) for col in zip(*rows)])
 

--- a/nireports/reportlets/utils.py
+++ b/nireports/reportlets/utils.py
@@ -44,8 +44,8 @@ import nibabel as nb
 import numpy as np
 import numpy.typing as npt
 from nibabel.spatialimages import SpatialImage
-from svgutils.transform import SVGFigure
 
+import nireports._vendored.svgutils.transform as svgt
 from nireports.reportlets import compression_missing_msg, have_compression
 
 from ..tools.ndimage import load_api
@@ -179,12 +179,11 @@ def svg2str(display_object: DisplayObject, dpi: int = 300) -> str:
     return image_buf.getvalue()
 
 
-def combine_svg(svg_list: list[SVGFigure], axis="vertical") -> SVGFigure:
+def combine_svg(svg_list: list[svgt.SVGFigure], axis="vertical") -> svgt.SVGFigure:
     """
     Composes the input svgs into one standalone svg
     """
     import numpy as np
-    import svgutils.transform as svgt
 
     # Read all svg files and get roots
     svgs = [svgt.fromstring(f.encode("utf-8")) for f in svg_list]
@@ -340,8 +339,8 @@ def _3d_in_file(
 
 
 def compose_view(
-    bg_svgs: list[SVGFigure],
-    fg_svgs: list[SVGFigure],
+    bg_svgs: list[svgt.SVGFigure],
+    fg_svgs: list[svgt.SVGFigure],
     ref: int = 0,
     out_file: ty.Union[str, os.PathLike[str]] = "report.svg",
 ) -> str:
@@ -370,12 +369,11 @@ def compose_view(
 
 
 def _compose_view(
-    bg_svgs: list[SVGFigure],
-    fg_svgs: list[SVGFigure],
+    bg_svgs: list[svgt.SVGFigure],
+    fg_svgs: list[svgt.SVGFigure],
     ref: int = 0,
 ) -> list[str]:
-    from svgutils.compose import Unit
-    from svgutils.transform import GroupElement
+    from nireports._vendored.svgutils.compose import Unit
 
     if fg_svgs is None:
         fg_svgs = []
@@ -397,7 +395,7 @@ def _compose_view(
 
     # Compose the views panel: total size is the width of
     # any element (used the first here) and the sum of heights
-    fig = SVGFigure(Unit(f"{width}px"), Unit(f"{heights[:nsvgs].sum()}px"))
+    fig = svgt.SVGFigure(Unit(f"{width}px"), Unit(f"{heights[:nsvgs].sum()}px"))
 
     yoffset = 0
     for i, r in enumerate(roots):
@@ -410,8 +408,8 @@ def _compose_view(
     # Group background and foreground panels in two groups
     if fg_svgs:
         newroots = [
-            GroupElement(roots[:nsvgs], {"class": "background-svg"}),
-            GroupElement(roots[nsvgs:], {"class": "foreground-svg"}),
+            svgt.GroupElement(roots[:nsvgs], {"class": "background-svg"}),
+            svgt.GroupElement(roots[nsvgs:], {"class": "foreground-svg"}),
         ]
     else:
         newroots = roots

--- a/nireports/reportlets/utils.py
+++ b/nireports/reportlets/utils.py
@@ -179,7 +179,7 @@ def svg2str(display_object: DisplayObject, dpi: int = 300) -> str:
     return image_buf.getvalue()
 
 
-def combine_svg(svg_list: list[svgt.SVGFigure], axis="vertical") -> svgt.SVGFigure:
+def combine_svg(svg_list: list[str], axis="vertical") -> svgt.SVGFigure:
     """
     Composes the input svgs into one standalone svg
     """

--- a/nireports/reportlets/xca.py
+++ b/nireports/reportlets/xca.py
@@ -348,14 +348,14 @@ def compcor_variance_plot(
             ax[m].text(
                 0,
                 100 * thr,
-                "{:.0f}".format(100 * thr),
+                f"{100 * thr:.0f}",
                 fontsize="x-small",
                 bbox=bbox_txt,
             )
             ax[m].text(
                 varexp[thr][0],
                 25,
-                "{} components explain\n{:.0f}% of variance".format(varexp[thr][0], 100 * thr),
+                f"{varexp[thr][0]} components explain\n{100 * thr:.0f}% of variance",
                 rotation=90,
                 horizontalalignment="center",
                 fontsize="xx-small",

--- a/nireports/tests/test_interfaces.py
+++ b/nireports/tests/test_interfaces.py
@@ -44,7 +44,7 @@ def _smoke_test_report(report_interface, artifact_name):
     save_artifacts = os.getenv("SAVE_CIRCLE_ARTIFACTS", False)
     if save_artifacts:
         copy(out_report, os.path.join(save_artifacts, artifact_name))
-    assert os.path.isfile(out_report), 'Report "%s" does not exist' % out_report
+    assert os.path.isfile(out_report), f'Report "{out_report}" does not exist'
 
 
 def test_CompCorVariancePlot(datadir):

--- a/nireports/tests/test_interfaces_segmentation.py
+++ b/nireports/tests/test_interfaces_segmentation.py
@@ -48,7 +48,7 @@ def _smoke_test_report(report_interface, artifact_name):
         save_artifacts = os.getenv("SAVE_CIRCLE_ARTIFACTS", False)
         if save_artifacts:
             copy(out_report, os.path.join(save_artifacts, artifact_name))
-        assert os.path.isfile(out_report), 'Report "%s" does not exist' % out_report
+        assert os.path.isfile(out_report), f'Report "{out_report}" does not exist'
 
 
 @pytest.mark.skipif(not has_fsl, reason="No FSL")

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "pyyaml >= 5.4",
     "seaborn >= 0.13",
     "templateflow >= 23.1",
+    "lxml >= 4.6",  # required by vendored svgutils
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,6 @@ dependencies = [
     "pybids >= 0.15.1",
     "pyyaml >= 5.4",
     "seaborn >= 0.13",
-    "svgutils >= 0.3.4",
     "templateflow >= 23.1",
 ]
 dynamic = ["version"]
@@ -214,7 +213,6 @@ module = [
   "nilearn.*",
   "templateflow.*",
   "bids.*",
-  "svgutils.*",
   "pylab",
   "mpl_toolkits.*",
   "nitransforms.*",

--- a/tox.ini
+++ b/tox.ini
@@ -95,6 +95,7 @@ description = "Run mypy type checking"
 labels = check
 deps =
   mypy
+  lxml-stubs
 extras = types
 commands =
   mypy nireports


### PR DESCRIPTION
Alternative to #170, and I think the more sustainable solution. If svgutils maintenance is ever resumed, we can consider unvendoring.