### PR TITLE
chore: Update pre-commit config, add codespell

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -69,7 +69,7 @@ jobs:
           - os: ubuntu-latest
             python-version: "3.10"
             dependencies: pre
-          # If we reenable Windows/Mac tests, add the following exclusions:
+          # If we re-enable Windows/Mac tests, add the following exclusions:
           # 32-bit is a Windows-only consideration
           # Only run 2 newest Python on Windows/Mac
           # Skip 32-bit Windows with Python 3.10+ (see #42)

--- a/.maint/ROADMAP.md
+++ b/.maint/ROADMAP.md
@@ -4,4 +4,4 @@ This document states how the roadmap is built, discussed and monitored by the Ma
 
 For example, if the GitHub Projects feature is used, this document will contain a link to the corresponding Project and document who is responsible of managing the project, contacting Contributors and Maintainers to monitor the progress of activities, organizing meetings and discussions around the activities, etc.
 
-This document may also indicate how the *milestones* feature of the project is used and, as for Projects, who is responsible of what coordination actions, their frequence, etc.
+This document may also indicate how the *milestones* feature of the project is used and, as for Projects, who is responsible of what coordination actions, their frequency, etc.

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: |
     )$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.2.0
+    rev: v5.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -27,7 +27,7 @@ repos:
       - id: check-vcs-permalinks
       - id: pretty-format-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.3.4
+    rev: v0.9.6
     hooks:
       - id: ruff
         args: [ --fix ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -32,3 +32,9 @@ repos:
       - id: ruff
         args: [ --fix ]
       - id: ruff-format
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.1
+    hooks:
+      - id: codespell
+        additional_dependencies:
+          - tomli


### PR DESCRIPTION
Given that we're checking codespell in CI, we should add it to pre-commit.