### PR TITLE
ENH: Prefer using NumPy's random number generator

### DIFF
--- a/nireports/tests/conftest.py
+++ b/nireports/tests/conftest.py
@@ -25,6 +25,7 @@
 import os
 
 import matplotlib.pyplot as plt
+import numpy as np
 import pytest
 from templateflow.api import get as get_template
 
@@ -65,3 +66,9 @@ def close_mpl_figures():
     """Automatically close all Matplotlib figures after each test."""
     yield
     plt.close("all")
+
+
+@pytest.fixture(autouse=True)
+def random_number_generator(request):
+    """Automatically set a fixed-seed random number generator for all tests."""
+    request.node.rng = np.random.default_rng(1234)

--- a/nireports/tests/test_dwi.py
+++ b/nireports/tests/test_dwi.py
@@ -120,7 +120,7 @@ def test_plot_tissue_values(tmp_path):
     )
 
 
-def test_nii_to_carpetplot_data(tmp_path, test_data_package, outdir):
+def test_nii_to_carpetplot_data(request, tmp_path, test_data_package, outdir):
     """Check the nii to carpet plot data function"""
 
     testdata_name = "ds000114_sub-01_ses-test_desc-trunc_dwi"
@@ -128,7 +128,10 @@ def test_nii_to_carpetplot_data(tmp_path, test_data_package, outdir):
     nii = nb.load(test_data_package / f"{testdata_name}.nii.gz")
     bvals = np.loadtxt(test_data_package / f"{testdata_name}.bval")
 
-    mask_data = np.round(82 * np.random.rand(nii.shape[0], nii.shape[1], nii.shape[2]))
+    rng = request.node.rng
+    mask_data = np.round(82 * rng.random((nii.shape[0], nii.shape[1], nii.shape[2]))).astype(
+        np.float32
+    )
 
     mask_nii = nb.Nifti1Image(mask_data, np.eye(4))
 

--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -180,8 +180,10 @@ def test_fmriplot(input_files, test_data_package, outdir):
 
 
 @pytest.mark.skipif(not have_compression, reason=compression_missing_msg)
-def test_plot_melodic_components(tmp_path, outdir):
+def test_plot_melodic_components(request, tmp_path, outdir):
     """Test plotting melodic components"""
+
+    rng = request.node.rng
 
     if outdir is None:
         outdir = Path(str(tmp_path))
@@ -194,19 +196,19 @@ def test_plot_melodic_components(tmp_path, outdir):
     melodic_dir = tmp_path / "melodic"
     melodic_dir.mkdir(exist_ok=True)
     # melodic_mix
-    mel_mix = np.random.randint(low=-5, high=5, size=[10, 2])
+    mel_mix = rng.integers(low=-5, high=5, size=[10, 2])
     mel_mix_file = str(melodic_dir / "melodic_mix")
     np.savetxt(mel_mix_file, mel_mix, fmt="%i")
     # melodic_FTmix
-    mel_ftmix = np.random.rand(2, 5)
+    mel_ftmix = rng.random((2, 5))
     mel_ftmix_file = str(melodic_dir / "melodic_FTmix")
     np.savetxt(mel_ftmix_file, mel_ftmix)
     # melodic_ICstats
-    mel_icstats = np.random.rand(2, 2)
+    mel_icstats = rng.random((2, 2))
     mel_icstats_file = str(melodic_dir / "melodic_ICstats")
     np.savetxt(mel_icstats_file, mel_icstats)
     # melodic_IC
-    mel_ic = np.random.rand(2, 2, 2, 2)
+    mel_ic = rng.random((2, 2, 2, 2))
     mel_ic_file = str(melodic_dir / "melodic_IC.nii.gz")
     mel_ic_img = nb.Nifti2Image(mel_ic, np.eye(4))
     mel_ic_img.to_filename(mel_ic_file)
@@ -221,7 +223,7 @@ def test_plot_melodic_components(tmp_path, outdir):
 
     # in_file
     in_fname = str(tmp_path / "in_file.nii.gz")
-    voxel_ts = np.random.rand(2, 2, 2, 10)
+    voxel_ts = rng.random((2, 2, 2, 10))
     in_file = nb.Nifti2Image(voxel_ts, np.eye(4))
     in_file.to_filename(in_fname)
     # report_mask
@@ -276,13 +278,15 @@ def test_compcor_variance_plot(tmp_path, test_data_package, outdir):
 
 
 @pytest.fixture
-def create_surface_dtseries():
+def create_surface_dtseries(request):
     """Create a dense timeseries CIFTI-2 file with only cortex structures"""
+
+    rng = request.node.rng
     out_file = _create_dtseries_cifti(
         timepoints=10,
         models=[
-            ("CIFTI_STRUCTURE_CORTEX_LEFT", np.random.rand(29696, 10)),
-            ("CIFTI_STRUCTURE_CORTEX_RIGHT", np.random.rand(29716, 10)),
+            ("CIFTI_STRUCTURE_CORTEX_LEFT", rng.random((29696, 10))),
+            ("CIFTI_STRUCTURE_CORTEX_RIGHT", rng.random((29716, 10))),
         ],
     )
     yield str(out_file)


### PR DESCRIPTION
Prefer using NumPy's random number generator and the relevant random number sampling functions introduced in NumPy 1.17.0 over the legacy versions.

Add a fixture for tests to set the random number generator consistently across tests.

Specify the data type when creating the mask data for the DWI NIfTI to carpetplot data test to avoid:
```
Expected type 'ArrayLike', got 'floating[_16Bit]' instead
```

Documentation:
https://numpy.org/doc/2.2/reference/random/new-or-different.html#what-s-new-or-different