### PR TITLE
ENH: Prefer using NumPy's random number generator

### DIFF
--- a/nireports/tests/test_interfaces.py
+++ b/nireports/tests/test_interfaces.py
@@ -101,9 +101,9 @@ def test_RaincloudPlot(orient, density, tmp_path):
     _smoke_test_report(rc_rpt, f"raincloud_orient-{orient}_density-{density}.svg")
 
 
-def test_FMRISummary(test_data_package, tmp_path, outdir):
+def test_FMRISummary(request, test_data_package, tmp_path, outdir):
     """Exercise the FMRISummary interface."""
-    rng = np.random.default_rng(2010)
+    rng = request.node.rng
 
     in_func = test_data_package / "sub-ds205s03_task-functionallocalizer_run-01_bold_volreg.nii.gz"
     ntimepoints = nb.load(in_func).shape[-1]

--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -49,10 +49,10 @@ from nireports.tools.timeseries import nifti_timeseries as _nifti_timeseries
 
 @pytest.mark.parametrize("tr", (None, 0.7))
 @pytest.mark.parametrize("sorting", (None, "ward", "linkage"))
-def test_carpetplot(tr, sorting, outdir):
+def test_carpetplot(request, tr, sorting, outdir):
     """Write a carpetplot"""
 
-    rng = np.random.default_rng(2010)
+    rng = request.node.rng
     plot_carpet(
         rng.normal(100, 20, size=(18000, 1900)),
         title="carpetplot with title",
@@ -141,9 +141,9 @@ def test_carpetplot(tr, sorting, outdir):
         ),
     ],
 )
-def test_fmriplot(input_files, test_data_package, outdir):
+def test_fmriplot(request, input_files, test_data_package, outdir):
     """Exercise the fMRIPlot class."""
-    rng = np.random.default_rng(2010)
+    rng = request.node.rng
 
     in_file = os.path.join(test_data_package, input_files[0])
     seg_file = (


### PR DESCRIPTION
Prefer using NumPy's random number generator and the relevant random number sampling functions introduced in NumPy 1.17.0 over the legacy versions through the fixture introduced in commit 9322cd6.

Left behind in commit 9322cd6.