### PR TITLE
MNT: Update ruff parameters

### DIFF
--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -151,7 +151,7 @@ def plot_heatmap(
         axs[i].tick_params(which="minor", bottom=False, left=False)
         axs[i].set_ylabel(f"$b$ = {bvals[i]}\n($n$ = {len(b_indices[i])})", fontsize=15)
 
-        marginal_H, edges = np.histogram(x, bins=bins[0], range=(0, int(imax)), density=True)
+        marginal_H, _edges = np.histogram(x, bins=bins[0], range=(0, int(imax)), density=True)
         axs[-1].bar(
             np.linspace(0, bins[0], num=bins[0], endpoint=False, dtype=int),
             marginal_H,

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -130,9 +130,7 @@ exclude = [
 ]
 
 [tool.ruff.lint]
-select = [
-  "F",
-  "E",
+extend-select = [
   "C",
   "W",
   "B",
@@ -141,7 +139,6 @@ select = [
   "RUF",
 ]
 ignore = [
-  "E203",
   "B019",
   "SIM108",
   "C901",


### PR DESCRIPTION
The default ruleset automatically excludes `E` rules that are not compatible with `ruff format`. Use `extend-select` over `select` to avoid such rules.

I cannot find a `C` ruleset. Rulesets that start with `C`:
* `COM` raises errors that seem spurious to me
* `C4`  raises no errors, so keep this ruleset
* `CPY` raises errors that I don't want to fix
* `C90` we disable the only error in this ruleset (`C901`) so it makes no sense keeping it

According to the Scientific Python Library Development Guide, `W` rules are not required if using a formatter:
	https://learn.scientific-python.org/development/guides/style/#ruff

Finally, add `B` rules.