### PR TITLE
MAINT: Filter Python 3.9 min warnings

### DIFF
--- a/nireports/tests/conftest.py
+++ b/nireports/tests/conftest.py
@@ -23,6 +23,7 @@
 """py.test configuration file"""
 
 import os
+import sys
 
 import matplotlib.pyplot as plt
 import numpy as np
@@ -72,3 +73,23 @@ def close_mpl_figures():
 def random_number_generator(request):
     """Automatically set a fixed-seed random number generator for all tests."""
     request.node.rng = np.random.default_rng(1234)
+
+
+def pytest_configure(config):
+    if sys.version_info < (3, 10):
+        config.addinivalue_line(
+            "filterwarnings",
+            "ignore:.*Fetchers from the nilearn.datasets module will be.*:FutureWarning",
+        )
+        config.addinivalue_line(
+            "filterwarnings",
+            'ignore:.*"is not" with a literal. Did you mean.*:SyntaxWarning',
+        )
+        config.addinivalue_line(
+            "filterwarnings",
+            "ignore:.*No contour levels were found within the data range.*:UserWarning",
+        )
+        config.addinivalue_line(
+            "filterwarnings",
+            "ignore:.*A value is trying to be set on a copy of a slice from a DataFrame.*:Warning",  # noqa:E501
+        )

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -185,7 +185,6 @@ filterwarnings = [
 ]
 junit_family = "xunit2"
 
-
 [tool.coverage.run]
 branch = true
 omit = [


### PR DESCRIPTION
Filter Python 3.9 min warnings: these warnings are being raised by the code in the packages that are being used when setting the dependencies to the minimum required version for Python 3.9, i.e. they do not stem from the `nireports` code base.

Fixes:
```
.tox/py39-min/lib/python3.9/site-packages/nilearn/datasets/__init__.py:86
 FutureWarning: Fetchers from the nilearn.datasets module will be updated
 in version 0.9 to return python strings instead of bytes and Pandas
 dataframes instead of Numpy arrays.
```

and
```
.tox/py39-min/lib/python3.9/site-packages/nilearn/glm/first_level/first_level.py:147:
 SyntaxWarning: "is not" with a literal. Did you mean "!="?
      if ((noise_model[:2] != 'ar') and (noise_model is not 'ols')):
```

and
```
nireports/tests/test_interfaces_segmentation.py::test_ROIsPlot
nireports/tests/test_interfaces_segmentation.py::test_ROIsPlot2
  .tox/py39-min/lib/python3.9/site-packages/nilearn/plotting/displays.py:101:
 UserWarning: No contour levels were found within the data range.
    im = getattr(ax, type)(data_2d.copy(),
```

and
```
nireports/tests/test_reportlets.py::test_plot_melodic_components
  /home/runner/work/nireports/nireports/nireports/reportlets/xca.py:184:
 UserWarning: No contour levels were found within the data range.
    ax1.contour(mask_sl[j], levels=[0.5], colors="k", linewidths=0.5)
```

and
```
nireports/tests/test_reportlets.py::test_plot_raincloud[True-h]
nireports/tests/test_reportlets.py::test_plot_raincloud[True-v]
nireports/tests/test_reportlets.py::test_plot_raincloud[False-h]
nireports/tests/test_reportlets.py::test_plot_raincloud[False-v]
.tox/py39-min/lib/python3.9/site-packages/pandas/core/generic.py:7562:
 SettingWithCopyWarning:
    A value is trying to be set on a copy of a slice from a DataFrame

    See the caveats in the documentation:
 https://pandas.pydata.org/pandas-docs/stable/user_guide/indexing.html#returning-a-view-versus-a-copy
      result[mask] = np.nan
```

raised for example in:
https://github.com/nipreps/nireports/actions/runs/13598467127/job/38020303628#step:14:481