### PR TITLE
ENH: Add output_name_pattern for PET

### DIFF
--- a/nireports/assembler/report.py
+++ b/nireports/assembler/report.py
@@ -54,11 +54,14 @@ OUTPUT_NAME_PATTERN = [
     "{extension<.html|.svg>|.html}",
     "sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]"
     "[_dir-{direction}][_run-{run}][_space-{space}][_cohort-{cohort}][_desc-{desc}]"
-    "[_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|"
+    "[_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|"
     "angio|dseg|mask|dwi|epiref|T2starw|MTw|TSE>}]{extension<.html|.svg>|.html}",
     # "sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]"
     # "[_run-{run}][_space-{space}][_cohort-{cohort}][_fmapid-{fmapid}][_desc-{desc}]_"
     # "{suffix<fieldmap>}{extension<.html|.svg>|.html}",
+    ("sub-{subject}[_ses-{session}][_acq-{acquisition}][_rec-{reconstruction}]"
+     "[_run-{run}][_space-{space}][_cohort-{cohort}][_desc-{desc}]_{suffix<pet>}"
+     "{extension<.html|.svg|.png>|.html}")
 ]
 
 

--- a/nireports/assembler/report.py
+++ b/nireports/assembler/report.py
@@ -54,14 +54,14 @@ OUTPUT_NAME_PATTERN = [
     "{extension<.html|.svg>|.html}",
     "sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]"
     "[_dir-{direction}][_run-{run}][_space-{space}][_cohort-{cohort}][_desc-{desc}]"
-    "[_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|"
+    "[_{suffix<T1w|T2w|T1rho|T1map|T2map|T2star|FLAIR|FLASH|PDmap|PD|PDT2|inplaneT[12]|"
     "angio|dseg|mask|dwi|epiref|T2starw|MTw|TSE>}]{extension<.html|.svg>|.html}",
     # "sub-{subject}[_ses-{session}][_acq-{acquisition}][_ce-{ceagent}][_rec-{reconstruction}]"
     # "[_run-{run}][_space-{space}][_cohort-{cohort}][_fmapid-{fmapid}][_desc-{desc}]_"
     # "{suffix<fieldmap>}{extension<.html|.svg>|.html}",
-    ("sub-{subject}[_ses-{session}][_acq-{acquisition}][_rec-{reconstruction}]"
-     "[_run-{run}][_space-{space}][_cohort-{cohort}][_desc-{desc}]_{suffix<pet>}"
-     "{extension<.html|.svg|.png>|.html}")
+    "sub-{subject}[_ses-{session}][_acq-{acquisition}][_rec-{reconstruction}]"
+    "[_run-{run}][_space-{space}][_cohort-{cohort}][_desc-{desc}]_{suffix<pet>}"
+    "{extension<.html|.svg|.png>|.html}")
 ]
 
 

--- a/nireports/assembler/report.py
+++ b/nireports/assembler/report.py
@@ -61,7 +61,7 @@ OUTPUT_NAME_PATTERN = [
     # "{suffix<fieldmap>}{extension<.html|.svg>|.html}",
     "sub-{subject}[_ses-{session}][_acq-{acquisition}][_rec-{reconstruction}]"
     "[_run-{run}][_space-{space}][_cohort-{cohort}][_desc-{desc}]_{suffix<pet>}"
-    "{extension<.html|.svg|.png>|.html}")
+    "{extension<.html|.svg|.png>|.html}",
 ]
 
 


### PR DESCRIPTION
This PR closes #187 by adding PET information to the output_name_pattern, which is needed to generate reports for PET data.