### PR TITLE
feat: Allow fMRIPlot to take a detrend parameter

### DIFF
--- a/nireports/reportlets/modality/func.py
+++ b/nireports/reportlets/modality/func.py
@@ -44,6 +44,7 @@ class fMRIPlot:
         "spikes",
         "timeseries",
         "tr",
+        "detrend",
     )
 
     def __init__(
@@ -60,6 +61,7 @@ class fMRIPlot:
         nskip=0,
         sort_carpet=True,
         paired_carpet=False,
+        detrend=True,
     ):
         self.timeseries = timeseries
         self.segments = segments
@@ -67,6 +69,7 @@ class fMRIPlot:
         self.nskip = nskip
         self.sort_carpet = sort_carpet
         self.paired_carpet = paired_carpet
+        self.detrend = detrend
 
         if units is None:
             units = {}
@@ -132,11 +135,12 @@ class fMRIPlot:
         plot_carpet(
             self.timeseries,
             segments=self.segments,
-            subplot=grid[-1],
+            cmap="paired" if self.paired_carpet else None,
             tr=self.tr,
+            detrend=self.detrend,
+            subplot=grid[-1],
             sort_rows=self.sort_carpet,
             drop_trs=self.nskip,
-            cmap="paired" if self.paired_carpet else None,
         )
 
         if out_file is not None:


### PR DESCRIPTION
In ASLPrep, they prefer not to detrend, since then the control/label differences dominate. Otherwise they can use `fMRIPlot` without modification.

This adds a `detrend` parameter that is set to `True` for backwards compatibility.

I have incidentally reordered the arguments to `plot_carpet()` to match the order of parameters in the function definition.

Closes #189.