### PR TITLE
chore: Update and test minimum dependencies

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -56,13 +56,13 @@ dev = [
 ]
 
 test = [
-    "coverage[toml] >=5.2.1",
-    "packaging",
-    "pytest >= 6",
-    "pytest-cov >= 2.11",
-    "pytest-env",
-    "pytest-xdist >= 2.5",
-    "sphinx >= 6",
+    "coverage[toml] >=7.10",
+    "packaging >= 25.0",
+    "pytest >= 8.4",
+    "pytest-cov >= 6.2",
+    "pytest-env >= 1.1",
+    "pytest-xdist >= 3.7",
+    "sphinx >= 8.0",
 ]
 types = [
     "pandas-stubs",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,10 +28,10 @@ dependencies = [
     "numpy >= 1.20",
     "pandas >= 1.2",
     "pybids >= 0.15.1",
-    "pyyaml >= 5.4",
+    "pyyaml >= 6.0",
     "seaborn >= 0.13",
     "templateflow >= 23.1",
-    "lxml >= 4.6",  # required by vendored svgutils
+    "lxml >= 4.7",  # required by vendored svgutils
 ]
 dynamic = ["version"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -21,12 +21,12 @@ license = "Apache-2.0"
 requires-python = ">=3.10"
 dependencies = [
     "acres >= 0.2",
-    "matplotlib >= 3.5",
-    "nibabel >= 3.0.1",
-    "nilearn >= 0.8",
+    "matplotlib >= 3.6",
+    "nibabel >= 5.0",
+    "nilearn >= 0.10.1",
     "nipype >= 1.8.5",
-    "numpy >= 1.20",
-    "pandas >= 1.2",
+    "numpy >= 1.24",
+    "pandas >= 1.5",
     "pybids >= 0.15.1",
     "pyyaml >= 6.0",
     "seaborn >= 0.13",

--- a/tox.ini
+++ b/tox.ini
@@ -2,8 +2,8 @@
 requires =
   tox>=4
 envlist =
-  py3{9,10,11,12,13}-latest
-  py39-min
+  py3{10,11,12,13}-latest
+  py310-min
   py3{11,12,13}-pre
   style
   spellcheck
@@ -12,7 +12,6 @@ skip_missing_interpreters = true
 # Configuration that allows us to split tests across GitHub runners effectively
 [gh-actions]
 python =
-  3.9: py39
   3.10: py310
   3.11: py311
   3.12: py312
@@ -85,7 +84,6 @@ skip_install = true
 commands =
   ruff check --fix
   ruff format
-  ruff check --select ISC001
 
 [testenv:typecheck]
 description = "Run mypy type checking"


### PR DESCRIPTION
py310-min wasn't being run properly after #192 because tox hadn't been updated. My bad.

I went ahead and adopted SPEC0+1yr. I made https://github.com/nipreps/speczeroplus/blob/main/spec-0000/chart.md to create the gantt chart rather than eyeballing the main page. I added nibabel and nilearn as well, so we only support a 3 year window of those tools.