### PR TITLE
test: Check colormap equivalence, modulo alpha

### DIFF
--- a/nireports/tests/test_reportlets.py
+++ b/nireports/tests/test_reportlets.py
@@ -593,14 +593,10 @@ def test_create_cmap(outdir):
     assert np.all(0.0 <= ls_cmap._lut[:, -1]) and np.all(ls_cmap._lut[:, -1] <= max_alpha)  # noqa: SIM300
     # Check that all values (excluding the bad/over/under) are monotonically increasing
     assert np.all(np.diff(ls_cmap._lut[: ls_cmap.N - 1, -1]) >= 0)
-    assert [
-        key1 == key2
-        for key1, key2 in zip(orig_cmap._segmentdata.keys(), ls_cmap._segmentdata.keys())
-    ]
-    assert [
-        np.allclose(val1, val2)
-        for val1, val2 in zip(orig_cmap._segmentdata.values(), ls_cmap._segmentdata.values())
-    ]
+    assert list(orig_cmap._segmentdata) == list(ls_cmap._segmentdata)
+    for key in orig_cmap._segmentdata:
+        if key != "alpha":
+            assert np.allclose(orig_cmap._segmentdata[key], ls_cmap._segmentdata[key])
 
     fig, ax = plt.subplots(1, 1, figsize=(12, 10), constrained_layout=True)
     _ = plt.colorbar(plt.cm.ScalarMappable(cmap=ls_cmap), cax=ax, orientation="horizontal")


### PR DESCRIPTION
The tests added in #151 had assertions that could not fail. I've updated to what I think was the intent.

@jhlegarreta Can you please confirm?