### PR TITLE
MAINT: Update pre-commit hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -13,7 +13,7 @@ exclude: |
     )$
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v5.0.0
+    rev: v6.0.0
     hooks:
       - id: trailing-whitespace
       - id: end-of-file-fixer
@@ -27,7 +27,7 @@ repos:
       - id: check-vcs-permalinks
       - id: pretty-format-json
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.12.2
+    rev: v0.13.0
     hooks:
       - id: ruff-check
         args: [ --fix ]


### PR DESCRIPTION
I was surprised pre-commit doesn't create autoupdate PRs.

It turns out [pre-comit.ci](https://pre-commit.ci/) is not enabled for this repository. Instead, pre-commit is run by the [pre-commit GitHub Action](https://github.com/pre-commit/action):
> this action is in maintenance-only mode and will not be accepting new features.
> 
> generally you want to use [pre-commit.ci](https://pre-commit.ci/) which is faster and has more features.

Created #212 for that.