### PR TITLE
FIX: Specify standardization strategy in carpet plot data cleaning

### DIFF
--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -304,7 +304,7 @@ def plot_carpet(
     if detrend:
         from nilearn.signal import clean
 
-        data = clean(data.T, t_r=tr, filter=False).T
+        data = clean(data.T, t_r=tr, filter=False, standardize="zscore_sample").T
 
     # We want all subplots to have the same dynamic range
     vminmax = np.percentile(data[:, drop_trs:], [2, 98])


### PR DESCRIPTION
Specify standardization strategy in carpet plot data cleaning: set the standardization explicitly to `zscore_sample` to keep the current strategy.

Fixes:
```
  nireports/tests/test_dwi.py::test_nii_to_carpetplot_data
  nireports/tests/test_interfaces.py::test_FMRISummary
    nireports/reportlets/nuisance.py:300: FutureWarning:
 The default strategy for standardize is currently 'zscore' which
 incorrectly uses population std to calculate sample zscores.
 The new strategy 'zscore_sample' corrects this behavior by using
 the sample std. In release 0.14.0, the default strategy will be
 replaced by the new strategy, the 'zscore' option will be removed.
 and using standardize=True will fall back to 'zscore_sample'.
 To avoid this warning, please use 'zscore_sample' instead.
      data = clean(data.T, t_r=tr, filter=False).T
```

raised for example at:
https://github.com/nipreps/nireports/actions/runs/22579217636/job/65406364989#step:14:342