### PR TITLE
FIX: Avoid attempting to write a read-only array

### DIFF
--- a/nireports/reportlets/nuisance.py
+++ b/nireports/reportlets/nuisance.py
@@ -888,7 +888,10 @@ def confounds_correlation_plot(
     gs_descending = gs_descending[:max_dim]
     features = [p for p in corr.columns if p in gs_descending]
     corr = corr.loc[features, features]
-    np.fill_diagonal(corr.values, 0)
+
+    arr = corr.to_numpy(copy=True)  # writable copy
+    np.fill_diagonal(arr, 0.0)
+    corr = pd.DataFrame(arr, index=corr.index, columns=corr.columns)
 
     figure = figure if figure is not None else plt.figure(figsize=(15, 5))
     gs = GridSpec(1, 21)


### PR DESCRIPTION
Avoid attempting to write a read-only array: a `DataFrame.values` can be non-writeable (a view), so calling `np.fill_diagonal` can raise a `ValueError` telling that the array is read-only.

This patch set copies the array values into a writeable numpy array, fills the diagonal values with zeros, and builds a pandas DataFrame back to be used as the object that gets plot in the heatmap.

Fixes:
```
nireports/tests/test_interfaces.py:66:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
nireports/nireports/tests/test_interfaces.py:42:
 in _smoke_test_report
    out_report = report_interface.run().outputs.out_file
                 ^^^^^^^^^^^^^^^^^^^^^^
python3.14/site-packages/nipype/interfaces/base/core.py:401: in run
    runtime = self._run_interface(runtime)
              ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
nireports/interfaces/nuisance.py:136: in _run_interface
    confounds_correlation_plot(
nireports/nireports/reportlets/nuisance.py:891:
 in confounds_correlation_plot
      np.fill_diagonal(corr.values, 0)

...

  # Write the value out into the diagonal.
> a.flat[:end:step] = val
  ^^^^^^^^^^^^^^^^^
E ValueError: underlying array is read-only
```

raised for example at:
https://github.com/nipreps/nireports/actions/runs/22579217636/job/65406364989#step:14:334