### PR TITLE
FIX: Avoid uninitialized values in DWI signal normalization

### DIFF
--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -488,11 +488,14 @@ def nii_to_carpetplot_data(
         if divide_by_b0:
             b0_data = nii_data[..., bvals == 0]
             bzero = np.mean(b0_data, -1)
-            nii_data = np.divide(
+            out = nii_data.copy()
+            np.divide(
                 nii_data,
-                bzero[..., np.newaxis],
-                where=bzero[..., np.newaxis] != 0,
+                bzero[..., None],
+                out=out,
+                where=bzero[..., None] != 0,
             )
+            nii_data = out
 
         if drop_b0:
             nii_data = nii_data[..., bvals > 0]

--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -488,14 +488,13 @@ def nii_to_carpetplot_data(
         if divide_by_b0:
             b0_data = nii_data[..., bvals == 0]
             bzero = np.mean(b0_data, -1)
-            out = nii_data.copy()
+            nii_data = nii_data.copy()
             np.divide(
                 nii_data,
                 bzero[..., None],
-                out=out,
+                out=nii_data,
                 where=bzero[..., None] != 0,
             )
-            nii_data = out
 
         if drop_b0:
             nii_data = nii_data[..., bvals > 0]


### PR DESCRIPTION
Avoid uninitialized values in DWI signal normalization: copy the raw data to a helper array and specificy it as the value for the `out` parameter so that values that lie outside the mask keep their original values.

Fixes:
```
nireports/tests/test_dwi.py::test_nii_to_carpetplot_data
  nireports/reportlets/modality/dwi.py:491:
 UserWarning:
 'where' used without 'out', expect unitialized memory in output.
 If this is intentional, use out=None.
      nii_data = np.divide(
```

raised for example at:
https://github.com/nipreps/nireports/actions/runs/22579217636/job/65406364989#step:14:338