### PR TITLE
ENH: Make LaTeX optional in reportlet and avoid `rcParams` side effects

### DIFF
--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -56,16 +56,19 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         dependencies: [latest] # , pre]
         architecture: ['x64']
+        latex: [false, true]
         include:
           # Test minimum dependencies on oldest supported Python
           - os: ubuntu-latest
             python-version: "3.10"
             dependencies: min
+            latex: true
         exclude:
           # Do not test pre-releases for versions out of SPEC0
           - os: ubuntu-latest
             python-version: "3.10"
             dependencies: pre
+            latex: true
           # If we re-enable Windows/Mac tests, add the following exclusions:
           # 32-bit is a Windows-only consideration
           # Only run 2 newest Python on Windows/Mac
@@ -94,9 +97,15 @@ jobs:
           restore-keys: |
             apt-cache-v0
       - name: Install tex
+        if: ${{ matrix.latex }}
         run: |
           sudo apt-get update
           sudo apt-get install -y --no-install-recommends dvipng texlive texlive-latex-extra cm-super
+      - name: Show latex availability
+        run: |
+          echo "LaTeX matrix flag: ${{ matrix.latex }}"
+          which latex || true
+          latex --version || true
 
       - uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:

--- a/.github/workflows/build_test_deploy.yml
+++ b/.github/workflows/build_test_deploy.yml
@@ -56,19 +56,23 @@ jobs:
         python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
         dependencies: [latest] # , pre]
         architecture: ['x64']
-        latex: [false, true]
+        latex: [false]
         include:
           # Test minimum dependencies on oldest supported Python
           - os: ubuntu-latest
             python-version: "3.10"
             dependencies: min
+            latex: false
+          # Enable latex to exercise code paths that can take advantage
+          - os: ubuntu-latest
+            python-version: "3"
+            dependencies: latest
             latex: true
         exclude:
           # Do not test pre-releases for versions out of SPEC0
           - os: ubuntu-latest
             python-version: "3.10"
             dependencies: pre
-            latex: true
           # If we re-enable Windows/Mac tests, add the following exclusions:
           # 32-bit is a Windows-only consideration
           # Only run 2 newest Python on Windows/Mac

--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -30,6 +30,7 @@ from mpl_toolkits.mplot3d import art3d
 from nilearn.plotting import plot_anat
 
 from nireports.reportlets.nuisance import plot_raincloud
+from nireports.reportlets.utils import _latex_available
 
 
 def plot_dwi(dataobj, affine, gradient=None, **kwargs):
@@ -57,33 +58,35 @@ def plot_dwi(dataobj, affine, gradient=None, **kwargs):
 
     """
 
-    plt.rcParams.update(
-        {
-            "text.usetex": True,
-            "font.family": "sans-serif",
-            "font.sans-serif": ["Helvetica"],
-        }
-    )
-
     affine = np.diag(nb.affines.voxel_sizes(affine).tolist() + [1])
     affine[:3, 3] = -1.0 * (affine[:3, :3] @ ((np.array(dataobj.shape) - 1) * 0.5))
 
     vmax = kwargs.pop("vmax", None) or np.percentile(dataobj, 98)
     cut_coords = kwargs.pop("cut_coords", None) or (0, 0, 0)
-
-    return plot_anat(
-        nb.Nifti1Image(dataobj, affine, None),
-        vmax=vmax,
-        cut_coords=cut_coords,
-        title=(
-            r"Reference $b$=0"
-            if gradient is None
-            else f"""\
-$b$={gradient[3].astype(int)}, \
-$\\vec{{b}}$ = ({", ".join(str(v) for v in gradient[:3])})"""
-        ),
-        **kwargs,
+    title = (
+        r"Reference $b$=0"
+        if gradient is None
+        else f"""\
+        $b$={gradient[3].astype(int)}, \
+        $\\vec{{b}}$ = ({", ".join(str(v) for v in gradient[:3])})"""
     )
+
+    with mpl.rc_context(
+        {
+            "text.usetex": _latex_available(),
+            "font.family": "sans-serif",
+            "font.sans-serif": ["Helvetica"],
+        }
+    ):
+        display = plot_anat(
+            nb.Nifti1Image(dataobj, affine, None),
+            vmax=vmax,
+            cut_coords=cut_coords,
+            title=title,
+            **kwargs,
+        )
+
+    return display
 
 
 def plot_heatmap(

--- a/nireports/reportlets/utils.py
+++ b/nireports/reportlets/utils.py
@@ -32,6 +32,7 @@ from __future__ import annotations
 import base64
 import os
 import re
+import shutil
 import subprocess
 import typing as ty
 import warnings
@@ -542,3 +543,8 @@ def get_parula() -> mpl.colors.LinearSegmentedColormap:
     ]
 
     return LinearSegmentedColormap.from_list("parula", cm_data)
+
+
+def _latex_available() -> bool:
+    """Return True when a LaTeX executable is available on PATH."""
+    return shutil.which("latex") is not None

--- a/nireports/tests/test_dwi.py
+++ b/nireports/tests/test_dwi.py
@@ -26,6 +26,7 @@ import nibabel as nb
 import numpy as np
 import pytest
 from matplotlib import pyplot as plt
+from matplotlib import rcParams
 
 from nireports.reportlets.modality.dwi import (
     get_segment_labels,
@@ -36,6 +37,29 @@ from nireports.reportlets.modality.dwi import (
 )
 from nireports.reportlets.nuisance import plot_carpet
 from nireports.tests.utils import _generate_raincloud_random_data
+
+
+@pytest.mark.parametrize("latex_available", [False, True])
+def test_plot_dwi_does_not_leak_rcparams(monkeypatch, latex_available):
+    """plot_dwi must not mutate global matplotlib rcParams."""
+    old_usetex = rcParams["text.usetex"]
+    old_family = rcParams["font.family"]
+    old_sans = rcParams["font.sans-serif"]
+
+    # Force the no-LaTeX path through the helper
+    monkeypatch.setattr(
+        "nireports.reportlets.modality.dwi._latex_available", lambda: latex_available
+    )
+
+    data = np.zeros((10, 10, 10), dtype=float)
+    affine = np.eye(4)
+
+    _ = plot_dwi(data, affine)
+
+    # rcParams should be restored after plot_dwi exits
+    assert rcParams["text.usetex"] == old_usetex
+    assert rcParams["font.family"] == old_family
+    assert rcParams["font.sans-serif"] == old_sans
 
 
 def test_plot_dwi(tmp_path, test_data_package, outdir):

--- a/nireports/tests/test_dwi_integration.py
+++ b/nireports/tests/test_dwi_integration.py
@@ -1,0 +1,65 @@
+# emacs: -*- mode: python; py-indent-offset: 4; indent-tabs-mode: nil -*-
+# vi: set ft=python sts=4 ts=4 sw=4 et:
+#
+# Copyright 2024 The NiPreps Developers <nipreps@gmail.com>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# We support and encourage derived works from this project, please read
+# about our expectations at
+#
+#     https://www.nipreps.org/community/licensing/
+#
+
+import matplotlib as mpl
+import numpy as np
+import pytest
+
+from nireports.reportlets.modality.dwi import plot_dwi
+from nireports.reportlets.utils import _latex_available
+
+
+@pytest.mark.parametrize("expect_latex", [False, True], ids=["no-latex", "with-latex"])
+def test_plot_dwi_uses_latex_typography(monkeypatch, expect_latex):
+    """Check that plot_dwi enables the expected typography settings."""
+
+    has_latex = _latex_available()
+    if expect_latex != has_latex:
+        pytest.skip(
+            f"This parameter requires LaTeX  {'available' if expect_latex else 'unavailable'}."
+        )
+
+    observed = {}
+
+    def fake_plot_anat(*args, **kwargs):
+        observed["usetex"] = mpl.rcParams["text.usetex"]
+        observed["family"] = mpl.rcParams["font.family"]
+        observed["sans-serif"] = mpl.rcParams["font.sans-serif"]
+        observed["title"] = kwargs["title"]
+
+        return None
+
+    monkeypatch.setattr(
+        "nireports.reportlets.modality.dwi.plot_anat",
+        fake_plot_anat,
+    )
+
+    data = np.random.default_rng(0).normal(size=(10, 10, 10))
+    affine = np.eye(4)
+
+    plot_dwi(data, affine)
+
+    assert observed["usetex"] is expect_latex
+    assert observed["family"] == ["sans-serif"]
+    assert observed["sans-serif"] == ["Helvetica"]
+    assert observed["title"]


### PR DESCRIPTION
Only enable `text.usetex` when LaTeX is available, and wrap matplotlib style changes in `rc_context` so they do not leak globally.

Update tests to mock `_latex_available()` and assert `plot_dwi` leaves global `rcParams` unchanged.

Add an integration test to check whether the LaTeX typography is actually used when LaTeX is available on the system.

Add a LaTeX matrix axis to build/test workflow and install LaTeX conditioned on its value  to check the functions with/without LaTeX.

Fixes #251.