### PR TITLE
MNT: Ignore the JetBrains IDE project config folder

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -131,7 +131,8 @@ dmypy.json
 # Pyre type checker
 .pyre/
 
-# VSCode configuration
+# IDE configuration
+.idea/
 .vscode/
 
 # Sphinx documentation


### PR DESCRIPTION
Ignore the JetBrains IDE project config folder.