### PR TITLE
MNT: Upper bound the `hatchling` version to fix `twine` incompatibility

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.27", "hatch-vcs", "nipreps-versions"]
+requires = ["hatchling>=1.27, < 1.32", "hatch-vcs", "nipreps-versions"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
The new version of `hatchling` (1.32) generates metadata version 2.5, which is not yet supported by `twine`. Upper bound the `hatchling` version to fix the issue.

Fixes:
```
Run /tmp/baipp/bin/python -m twine check --strict /tmp/baipp/dist/*
/tmp/baipp/bin/python -m twine check --strict /tmp/baipp/dist/*
shell: /usr/bin/bash --noprofile --norc -e -o pipefail {0}
env:
  FORCE_COLOR: true
  TEMPLATEFLOW_HOME: /tmp/templateflow
  UV_CACHE_DIR: /tmp/baipp-uv_cache_dir
  REQS_HASH:
    567a34dc4c0412a37952d1396403566f0d030748c60574977cdf16bcfdbca5da
Checking
  /tmp/baipp/dist/nireports-26.0.0.dev128+g0487a71cf-py3-none-any.whl:
  ERROR    InvalidDistribution:
  Invalid distribution metadata: '2.5' is not a valid metadata version
 ```

 raised for example in:
 https://github.com/nipreps/nireports/actions/runs/31669147845/job/94350034448?pr=276

 Documentation:
 https://stackoverflow.com/a/79939707
 https://github.com/pypa/hatch/issues/2292#issue-4559640411