### PR TITLE
MNT: Bump `hynek/build-and-inspect-python-package` to v3.0.1

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["hatchling>=1.27, < 1.32", "hatch-vcs", "nipreps-versions"]
+requires = ["hatchling>=1.27", "hatch-vcs", "nipreps-versions"]
 build-backend = "hatchling.build"
 
 [project]


### PR DESCRIPTION
Versions of `build-and-inspect-python-package` earlier than v3 do not support `metadata` version 2.5; see
https://github.com/pypa/hatch/issues/2292. Revert upper bounding `hatchling` (commit 784dbf1) as the error analysis that led to conclude that this was the cause was not accurate:
https://github.com/nipreps/nifreeze/pull/485#issuecomment-5294263569

`hynek/build-and-inspect-python-package` had already been bumped to the v3.0.1 release commit hash by depndabot in commit 50efef0.