### PR TITLE
fix: disable colorbar after default switch

### DIFF
--- a/nireports/reportlets/modality/dwi.py
+++ b/nireports/reportlets/modality/dwi.py
@@ -83,6 +83,7 @@ def plot_dwi(dataobj, affine, gradient=None, **kwargs):
             vmax=vmax,
             cut_coords=cut_coords,
             title=title,
+            colorbar=kwargs.pop("colorbar", False),
             **kwargs,
         )
 

--- a/nireports/reportlets/mosaic.py
+++ b/nireports/reportlets/mosaic.py
@@ -207,6 +207,9 @@ def plot_registration(
     if estimate_brightness:
         plot_params = robust_set_limits(anat_nii.get_fdata().reshape(-1), plot_params)
 
+    # nilearn 0.12.0 changed the colorbar default to True
+    plot_params.setdefault("colorbar", False)
+
     # FreeSurfer ribbon.mgz
     if contour:
         contour = nb.Nifti1Image.from_image(contour)
@@ -282,12 +285,16 @@ def _plot_anat_with_contours(
     if not levels:
         levels = [[0.5]] * nsegs
 
+    # nilearn 0.12.0 changed the colorbar default to True
+    plot_params.setdefault("colorbar", False)
+
     # anatomical
     display = plot_anat(image, **plot_params)
 
     # remove plot_anat -specific parameters
     plot_params.pop("display_mode")
     plot_params.pop("cut_coords")
+    plot_params.pop("colorbar")
 
     plot_params["linewidths"] = 0.5
     for i in reversed(range(nsegs)):
@@ -331,6 +338,7 @@ def plot_segmentation(anat_file: str, segmentation: str, out_file: str, **kwargs
         title=kwargs.get("title"),
         vmax=vmax,
         vmin=vmin,
+        colorbar=kwargs.get("colorbar", False),
     )
     disp.add_contours(
         seg_ras_plumb,


### PR DESCRIPTION
explicitly sets `colorbar=False` within `plot_anat` calls